### PR TITLE
feat: add OAuth2 social login (Kakao, Naver, Google)

### DIFF
--- a/backend/src/main/java/com/ottproject/ottbackend/config/MailConfig.java
+++ b/backend/src/main/java/com/ottproject/ottbackend/config/MailConfig.java
@@ -11,16 +11,16 @@
     @Configuration // spring 설정 클래스로 등록
     public class MailConfig {
 
-        @Value("${spring.mail.host}") // application.yml 에서 메일 호스트 주입
+        @Value("${spring.mail.host}") // application-dev.yml 에서 메일 호스트 주입
         private String host;
 
-        @Value("${spring.mail.port}") // application.yml 에서 메일 포트 주입
+        @Value("${spring.mail.port}") // application-dev.yml 에서 메일 포트 주입
         private int port;
 
-        @Value("${spring.mail.username}") // application.yml 에서 메일 사용자명 주입
+        @Value("${spring.mail.username}") // application-dev.yml 에서 메일 사용자명 주입
         private String username;
 
-        @Value("${spring.mail.password}") // application.yml 에서 메일 비밀번호 주입
+        @Value("${spring.mail.password}") // application-dev.yml 에서 메일 비밀번호 주입
         private String password;
 
         @Bean // javaMailSender Bean 등록 (이메일 발송을 위한 핵심 컴포넌트)

--- a/backend/src/main/java/com/ottproject/ottbackend/config/WebSecurityConfig.java
+++ b/backend/src/main/java/com/ottproject/ottbackend/config/WebSecurityConfig.java
@@ -1,5 +1,8 @@
 package com.ottproject.ottbackend.config;
 
+import com.ottproject.ottbackend.handler.OAuth2FailureHandler;
+import com.ottproject.ottbackend.handler.OAuth2SuccessHandler;
+import com.ottproject.ottbackend.service.CustomOAuth2UserService;
 import com.ottproject.ottbackend.service.CustomUserDetailsService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -10,34 +13,73 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
+/**
+ * Spring Security 설정 클래스
+ * 웹 애플리케이션의 보안 설정을 담당
+ *
+ * 주요 기능:
+ * 1. 비밀번호 암호화 설정 (BCrypt)
+ * 2. HTTP 요청 인증/인가 설정
+ * 3. OAuth2 소셜 로그인 설정 (Google, Kakao, Naver)
+ * 4. 기존 이메일 로그인과 소셜 로그인 통합 관리
+ * 5. 세션 관리 설정
+ * 6. CSRF, HTTP Basic 인증 설정
+ */
 @Configuration // spring 설정 클래스
 @EnableWebSecurity // spring security 활성화
 @RequiredArgsConstructor // final 필드에 대한 생성자 자동 생성 (의존성 주입용)
 public class WebSecurityConfig {
 
-    private  final CustomUserDetailsService customUserDetailsService; // CustomUserDetailService 주입
+    private final CustomUserDetailsService customUserDetailsService; // 기존 이메일 로그인용 사용자 서비스 주입
+    private final CustomOAuth2UserService customOAuth2UserService; // OAuth2 소셜 로그인용 사용자 서비스 주입
+    private final OAuth2SuccessHandler oAuth2SuccessHandler; // OAuth2 성공 핸들러 주입
+    private final OAuth2FailureHandler oAuth2FailureHandler; // OAuth2 실패 핸들러 주입
+
     @Bean // PasswordEncoder Bean 등록
     public PasswordEncoder passwordEncoder() { // 비밀번호 암호화를 위한 BCrypt 인코더
         return new BCryptPasswordEncoder();
     }
 
+    /**
+     * Spring Security 필터 체인 설정
+     * 웹 애플리케이션의 모든 보안 설정을 담당
+     *
+     * @param http HttpSecurity 객체
+     * @return SecurityFilterChain 설정된 보안 필터 체인
+     * @throws Exception 설정 중 발생할 수 있는 예외
+     */
     @Bean // securityFilterChain Bean 등록
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
                 .csrf(csrf -> csrf.disable()) // CSRF 보호 비활성화 (개발용)
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/auth/**").permitAll() // 모든 인증 관련 경로 허용
+                        .requestMatchers("/oauth2/**").permitAll() // OAuth2 관련 경로 허용 (소셜 로그인)
+                        .requestMatchers("/login/oauth2/code/**").permitAll() // OAuth2 콜백 URL 허용
+                        .requestMatchers("/api/oauth2/**").permitAll() // OAuth2 API 엔드포인트 허용
+                        .requestMatchers("/oauth2/success").permitAll() // OAuth2 성공 페이지 허용
+                        .requestMatchers("/oauth2/failure").permitAll() // OAuth2 실패 페이지 허용
+                        .requestMatchers("/").permitAll() // 루트 경로 허용 (헬스체크용)
+                        .requestMatchers("/health").permitAll() // 헬스체크 경로 허용
                         .anyRequest().authenticated() // 그 외 모든 요청은 인증 필요
                 )
                 .formLogin(form -> form.disable()) // 기본 로그인 폼 비활성화 (REST API용)
                 .httpBasic(basic -> basic.disable()) // HTTP Basic 인증 비활성화
+
+                // OAuth2 소셜 로그인 설정
+                .oauth2Login(oauth2 -> oauth2
+                        .successHandler(oAuth2SuccessHandler) // OAuth2 로그인 성공 시 처리할 핸들러
+                        .failureHandler(oAuth2FailureHandler) // OAuth2 로그인 실패 시 처리할 핸들러
+                        .userInfoEndpoint(userInfo -> userInfo
+                                .userService(customOAuth2UserService) // OAuth2 사용자 정보 처리 서비스 (customOAuth2UserService 사용)
+                        )
+                )
                 .sessionManagement(session -> session
                         .maximumSessions(1) // 동시 세션 수 제한(1개)
                         .maxSessionsPreventsLogin(false) // 기본 세션 무효화
                 )
-                .userDetailsService(customUserDetailsService); // customUserDetailService 등록
-        
-        return http.build(); // securityFilterChain 반환
+                .userDetailsService(customUserDetailsService); // 기존 이메일 로그인용 customUserDetailService 등록
+
+        return http.build(); // 설정된 securityFilterChain 반환
     }
 }
-

--- a/backend/src/main/java/com/ottproject/ottbackend/controller/OAuth2Controller.java
+++ b/backend/src/main/java/com/ottproject/ottbackend/controller/OAuth2Controller.java
@@ -1,0 +1,186 @@
+package com.ottproject.ottbackend.controller;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * OAuth2 소셜 로그인 관련 컨트롤러
+ * 실제 서비스에서 필요한 소셜 로그인 기능 제공
+ *
+ * 주요 기능:
+ * 1. 소셜 로그인 상태 확인
+ * 2. 소셜 로그인 URL 제공
+ * 3. 현재 로그인된 사용자 정보 조회
+ * 4. 소셜 로그인 로그아웃
+ */
+@Slf4j // Lombok 로깅 어노테이션
+@RestController // REST API 컨트롤러
+@RequestMapping("/api/oauth2") // 기본 경로 설정
+@RequiredArgsConstructor // final 필드에 대한 생성자 자동 생성
+@CrossOrigin(origins = "*") // CORS 설정 (개발용)
+public class OAuth2Controller {
+
+    /**
+     * 소셜 로그인 상태 확인 API
+     * 현재 사용자가 소셜 로그인으로 인증되었는지 확인
+     *
+     * @return 로그인 상태 정보
+     */
+    @GetMapping("/status") // GET 요청 처리 - /api/oauth2/status 경로로 접근
+    public ResponseEntity<Map<String, Object>> getOAuth2Status() { // HTTP 응답을 위한 ResponseEntity 반환
+        log.info("OAuth2 로그인 상태 확인 요청"); // 로그 출력 - 요청 시작을 알림
+
+        // Spring Security 컨텍스트에서 현재 인증 정보 가져오기
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        // 응답 데이터를 담을 Map 객체 생성
+        Map<String, Object> response = new HashMap<>();
+
+        // 인증 상태 확인 (로그인되어 있는지 체크)
+        if (authentication != null && authentication.isAuthenticated() &&
+                !"anonymousUser".equals(authentication.getName())) { // anonymousUser 는 로그인되지 않은 유저
+            // 로그인된 사용자인 경우 - 성공 응답 데이터 설정
+            response.put("authenticated", true); // 인증 상태를 true 로 설정
+            response.put("username", authentication.getName()); // 사용자명 (이메일) 설정
+            response.put("authorities", authentication.getAuthorities()); // 사용자 권한 정보 설정
+            response.put("principal", authentication.getPrincipal()); // 인증 주체 정보 설정
+            response.put("message", "소셜 로그인이 완료되었습니다."); // 성공 메시지 설정
+
+            // OAuth2 사용자인 경우 추가 정보 설정 (소셜 로그인 사용자만)
+            if (authentication.getPrincipal() instanceof org.springframework.security.oauth2.core.user.OAuth2User) {
+                // OAuth2User 로 캐스팅하여 소셜 로그인 사용자 정보 추출
+                org.springframework.security.oauth2.core.user.OAuth2User oauth2User =
+                        (org.springframework.security.oauth2.core.user.OAuth2User) authentication.getPrincipal();
+                response.put("oauth2User", true); // OAuth2 사용자임을 표시
+                response.put("provider", extractProvider(oauth2User.getAttributes())); // 소셜 로그인 제공자 설정
+            }
+        } else {
+            // 로그인되지 않은 사용자인 경우 - 실패 응답 데이터 설정
+            response.put("authenticated", false); // 인증 상태를 false 로 설정
+            response.put("message", "소셜 로그인이 필요합니다."); // 안내 메시지 설정
+            response.put("loginUrls", Map.of( // 소셜 로그인 URL들을 Map 으로 설정
+                    "google", "/oauth2/authorization/google", // Google 로그인 URL
+                    "kakao", "/oauth2/authorization/kakao", // Kakao 로그인 URL
+                    "naver", "/oauth2/authorization/naver" // Naver 로그인 URL
+            ));
+        }
+
+        return ResponseEntity.ok(response); // 200 OK 상태코드와 함께 응답 데이터 반환
+    }
+
+    /**
+     * 소셜 로그인 URL 제공 API
+     * 각 소셜 로그인 제공자의 로그인 URL을 제공
+     * 프론트엔드에서 소셜 로그인 버튼을 만들 때 사용
+     *
+     * @return 소셜 로그인 URL들 (JSON 형태)
+     */
+    @GetMapping("/login-urls") // GET 요청 처리 - /api/oauth2/login-urls 경로로 접근
+    public ResponseEntity<Map<String, Object>> getOAuth2LoginUrls() { // HTTP 응답을 위한 ResponseEntity 반환
+        log.info("OAuth2 로그인 URL 요청"); // 로그 출력 - 요청 시작을 알림
+
+        // 응답 데이터를 담을 Map 객체 생성
+        Map<String, Object> response = new HashMap<>();
+
+        // 소셜 로그인 URL들을 Map으로 설정
+        response.put("loginUrls", Map.of(
+                "google", "/oauth2/authorization/google", // Google 로그인 URL
+                "kakao", "/oauth2/authorization/kakao", // Kakao 로그인 URL
+                "naver", "/oauth2/authorization/naver" // Naver 로그인 URL
+        ));
+
+        return ResponseEntity.ok(response); // 200 OK 상태코드와 함께 응답 데이터 반환
+    }
+
+    /**
+     * 현재 로그인된 사용자 정보 조회 API
+     * 소셜 로그인으로 인증된 사용자의 상세 정보를 조회
+     *
+     * @return 사용자 정보 (JSON 형태)
+     */
+    @GetMapping("/user-info") // GET 요청 처리 - /api/oauth2/user-info 경로로 접근
+    public ResponseEntity<Map<String, Object>> getCurrentUserInfo() { // HTTP 응답을 위한 ResponseEntity 반환
+        log.info("현재 사용자 정보 조회 요청"); // 로그 출력 - 요청 시작을 알림
+
+        // Spring Security 컨텍스트에서 현재 인증 정보 가져오기
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        // 사용자 정보를 담을 Map 객체 생성
+        Map<String, Object> userInfo = new HashMap<>();
+
+        // 인증 상태 확인 (로그인되어 있는지 체크)
+        if (authentication != null && authentication.isAuthenticated() &&
+                !"anonymousUser".equals(authentication.getName())) { // anonymousUser 는 로그인되지 않은 유저
+            // 로그인된 사용자 정보 설정
+            userInfo.put("authenticated", true); // 인증 상태를 true 로 설정
+            userInfo.put("username", authentication.getName()); // 사용자명 (이메일) 설정
+            userInfo.put("authorities", authentication.getAuthorities()); // 사용자 권한 정보 설정
+            userInfo.put("principal", authentication.getPrincipal()); // 인증 주체 정보 설정
+
+            // OAuth2 사용자의 경우 추가 정보 설정 (소셜 로그인 사용자만)
+            if (authentication.getPrincipal() instanceof org.springframework.security.oauth2.core.user.OAuth2User) {
+                // OAuth2User 로 캐스팅하여 소셜 로그인 사용자 정보 추출
+                org.springframework.security.oauth2.core.user.OAuth2User oAuth2User =
+                        (org.springframework.security.oauth2.core.user.OAuth2User) authentication.getPrincipal();
+                userInfo.put("oauth2User", true); // OAuth2 사용자임을 표시
+                userInfo.put("provider", extractProvider(oAuth2User.getAttributes())); // 소셜 로그인 제공자 설정
+                userInfo.put("attributes", oAuth2User.getAttributes()); // OAuth2 속성 정보 설정 (소셜 로그인 제공자에서 받은 정보)
+            }
+        } else {
+            // 로그인되지 않은 경우 - 실패 응답 데이터 설정
+            userInfo.put("authenticated", false); // 인증 상태를 false 로 설정
+            userInfo.put("message", "로그인이 필요합니다."); // 안내 메시지 설정
+            return ResponseEntity.status(401).body(userInfo); // 401 Unauthorized 상태코드와 함께 응답 데이터 반환
+        }
+
+        return ResponseEntity.ok(userInfo); // 200 OK 상태코드와 함께 사용자 정보 반환
+    }
+
+    /**
+     * 소셜 로그인 로그아웃 API
+     * 현재 세션을 무효화하여 로그아웃 처리
+     *
+     * @return 로그아웃 결과 (JSON 형태)
+     */
+    @PostMapping("/logout") // POST 요청 처리 - /api/oauth2/logout 경로로 접근
+    public ResponseEntity<Map<String, Object>> logout() { // HTTP 응답을 위한 ResponseEntity 반환
+        log.info("OAuth2 로그아웃 요청"); // 로그 출력 - 요청 시작을 알림
+
+        // 현재 Spring Security 컨텍스트를 클리어하여 로그아웃 처리
+        SecurityContextHolder.clearContext(); // 인증 정보 삭제
+
+        // 로그아웃 결과를 담을 Map 객체 생성
+        Map<String, Object> response = new HashMap<>();
+
+        // 로그아웃 결과 데이터 설정
+        response.put("success", true); // 로그아웃 성공 상태 설정
+        response.put("message", "로그아웃이 완료되었습니다."); // 성공 메시지 설정
+
+        return ResponseEntity.ok(response); // 200 OK 상태코드와 함께 로그아웃 결과 반환
+    }
+
+    /**
+     * 소셜 로그인 제공자 추출
+     * OAuth2User attributes 에서 어떤 소셜 로그인을 사용했는지 판단
+     *
+     * @param attributes OAuth2User 의 속성 정보
+     * @return 소셜 로그인 제공자 (google, kakao, naver, unknown)
+     */
+    private String extractProvider(Map<String, Object> attributes) { // private 메서드 - 클래스 내부에서만 사용
+        if (attributes.containsKey("sub")) return "google"; // Google은 sub 필드가 있음
+        if (attributes.containsKey("kakao_account")) return "kakao"; // Kakao 는 kakao_account 필드가 있음
+        if (attributes.containsKey("response")) return "naver"; // Naver 는 response 필드가 있음
+        return "unknown"; // 알 수 없는 제공자
+    }
+}

--- a/backend/src/main/java/com/ottproject/ottbackend/dto/UserResponseDto.java
+++ b/backend/src/main/java/com/ottproject/ottbackend/dto/UserResponseDto.java
@@ -25,4 +25,5 @@ public class UserResponseDto {
     private boolean emailVerified; // 이메일 인증 여부
     private boolean enabled; // 계정 활성화 여부
     private LocalDateTime createdAt; // 가입일시
+    private LocalDateTime updatedAt; // 수정일시
 }

--- a/backend/src/main/java/com/ottproject/ottbackend/entity/User.java
+++ b/backend/src/main/java/com/ottproject/ottbackend/entity/User.java
@@ -39,26 +39,33 @@ public class User {
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
+    @Builder.Default
     private UserRole role = UserRole.USER;  // 사용자 권한 (기본값: USER)
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
+    @Builder.Default
     private AuthProvider authProvider = AuthProvider.LOCAL;  // 인증 제공자 (기본값: LOCAL)
 
     @Column(nullable = true)
     private String providerId;          // 소셜 로그인 ID (소셜 로그인용)
 
     @Column(nullable = false)
+    @Builder.Default
     private boolean emailVerified = false;  // 이메일 인증 여부 (기본값: false)
 
     @Column(nullable = false)
+    @Builder.Default
     private boolean enabled = true;     // 계정 활성화 여부 (기본값: true)
 
     @CreatedDate
     @Column(nullable = false)
-    private LocalDateTime createdAt;    // 생성일시 (자동 생성)
+    @Builder.Default
+    private LocalDateTime createdAt = LocalDateTime.now();    // 생성일시 (자동 생성)
 
     @LastModifiedDate
     @Column(nullable = false)
-    private LocalDateTime updatedAt;    // 수정일시 (자동 업데이트)
+    @Builder.Default
+    private LocalDateTime updatedAt = LocalDateTime.now();    // 수정일시 (자동 업데이트)
+
 }

--- a/backend/src/main/java/com/ottproject/ottbackend/handler/OAuth2FailureHandler.java
+++ b/backend/src/main/java/com/ottproject/ottbackend/handler/OAuth2FailureHandler.java
@@ -1,0 +1,83 @@
+package com.ottproject.ottbackend.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * OAuth2 소셜 로그인 실패 시 처리하는 핸들러
+ * 소셜 로그인 실패 시 에러 정보를 JSON 형태로 반환
+ *
+ * 주요 기능:
+ * 1. 소셜 로그인 실패 시 에러 로그 기록
+ * 2. JSON 형태의 에러 응답 전송
+ * 3. 적절한 HTTP 상태 코드 설정
+ */
+@Slf4j // 로깅 어노테이션 - log 객체 자동 생성
+@Component // Spring Bean으로 등록
+@RequiredArgsConstructor // final 필드에 대한 생성자 자동 생성
+public class OAuth2FailureHandler extends SimpleUrlAuthenticationFailureHandler {
+
+    private final ObjectMapper objectMapper; // JSON 변환용 객체 주입
+
+    /**
+     * OAuth2 소셜 로그인 실패 시 호출되는 메서드
+     *
+     * @param request HTTP 요청 객체
+     * @param response HTTP 응답 객체
+     * @param exception 인증 실패 예외 객체
+     */
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
+                                        AuthenticationException exception) throws IOException, ServletException {
+        log.error("OAuth2 로그인 실패: {}", exception.getMessage(), exception); // 에러 로그 기록
+
+        // 요청 헤더에서 Accept 타입 확인 (AJAX 요청인지 일반 요청인지 판단)
+        String acceptHeader = request.getHeader("Accept"); // Accept 헤더 확인
+        boolean isAjaxRequest = acceptHeader != null && acceptHeader.contains("application/json"); // JSON 요청인지 확인
+
+        if (isAjaxRequest) {
+            // AJAX 요청인 경우 JSON 응답 전송
+            sendErrorResponse(response, exception); // JSON 에러 응답 전송
+        } else {
+            // 일반 요청인 경우 프론트엔드로 리다이렉션 (SPA 애플리케이션용)
+            String redirectUrl = "http://localhost:3000/oauth2/failure?error=" + 
+                    java.net.URLEncoder.encode(exception.getMessage(), "UTF-8"); // 에러 메시지를 URL 파라미터로 전달
+            getRedirectStrategy().sendRedirect(request, response, redirectUrl); // 리다이렉션 전송
+        }
+    }
+
+    /**
+     * 에러 응답 전송 (JSON 형태)
+     * 소셜 로그인 실패 시 에러 정보를 JSON으로 변환하여 전송
+     *
+     * @param response HTTP 응답 객체
+     * @param exception 인증 실패 예외 객체
+     */
+    private void sendErrorResponse(HttpServletResponse response, AuthenticationException exception) throws IOException { // IO 예외를 던질 수 있음
+        // 에러 응답 생성 (JSON 형태)
+        Map<String, Object> errorResponse = new HashMap<>();
+        errorResponse.put("success", false); // 성공 여부
+        errorResponse.put("message", "소셜 로그인에 실패했습니다."); // 에러 메시지 (마침표 추가)
+        errorResponse.put("error", exception.getMessage()); // 상세 에러 메시지
+        errorResponse.put("timestamp", System.currentTimeMillis()); // 에러 발생 시간
+
+        // HTTP 상태 코드 설정 (401 Unauthorized)
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType("application/json;charset=UTF-8"); // JSON 응답 타입 설정
+
+        // JSON 응답 전송
+        String jsonResponse = objectMapper.writeValueAsString(errorResponse);
+        response.getWriter().write(jsonResponse);
+    }
+}

--- a/backend/src/main/java/com/ottproject/ottbackend/handler/OAuth2SuccessHandler.java
+++ b/backend/src/main/java/com/ottproject/ottbackend/handler/OAuth2SuccessHandler.java
@@ -1,0 +1,103 @@
+package com.ottproject.ottbackend.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * OAuth2 소셜 로그인 성공 시 처리하는 핸들러
+ * CustomOAuth2UserService에서 처리된 사용자 정보를 받아서 성공 응답을 전송
+ *
+ * 주요 기능:
+ * 1. 소셜 로그인 성공 후 JSON 응답 전송
+ * 2. 세션에 사용자 정보 저장 (필요한 경우)
+ * 3. 성공 로그 기록
+ */
+@Slf4j // Lombok 로깅 어노테이션 - log 객체 자동 생성
+@Component // Spring Bean으로 등록
+@RequiredArgsConstructor // final 필드에 대한 생성자 자동 생성
+public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler { // SimpleUrlAuthenticationSuccessHandler 상속
+
+    private final ObjectMapper objectMapper; // JSON 변환용 객체 주입
+
+    /**
+     * OAuth2 소셜 로그인 성공 시 호출되는 메서드
+     * CustomOAuth2UserService에서 이미 사용자 정보 처리가 완료된 상태
+     *
+     * @param request HTTP 요청 객체
+     * @param response HTTP 응답 객체
+     * @param authentication 인증 정보 객체 (CustomOAuth2UserService에서 처리된 OAuth2User 포함)
+     */
+    @Override // 부모 클래스의 메서드를 오버라이드
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+                                        Authentication authentication) throws IOException, ServletException { // IO 예외와 Servlet 예외를 던질 수 있음
+        log.info("OAuth2 로그인 성공 처리 시작"); // 로그 출력 - 요청 시작을 알림
+
+        // OAuth2 인증 토큰으로 캐스팅 (소셜 로그인 정보 포함)
+        OAuth2AuthenticationToken authToken = (OAuth2AuthenticationToken) authentication; // Authentication을 OAuth2AuthenticationToken으로 캐스팅
+        OAuth2User oAuth2User = authToken.getPrincipal(); // OAuth2 사용자 정보 추출
+
+        // CustomOAuth2UserService에서 추가한 사용자 정보 추출
+        Map<String, Object> attributes = oAuth2User.getAttributes(); // OAuth2User의 속성 정보 가져오기
+        String userEmail = (String) attributes.get("userEmail"); // 사용자 이메일 추출
+        String userName = (String) attributes.get("userName"); // 사용자 이름 추출
+        String authProvider = (String) attributes.get("authProvider"); // 인증 제공자 추출
+
+        log.info("OAuth2 로그인 성공 - 사용자: {}, 제공자: {}", userEmail, authProvider); // 로그 출력 - 성공 정보 기록
+
+        // 세션에 사용자 정보 저장 (로그인 상태 유지)
+        HttpSession session = request.getSession(); // HTTP 세션 객체 가져오기
+        session.setAttribute("userEmail", userEmail); // 세션에 이메일 저장
+        session.setAttribute("userName", userName); // 세션에 이름 저장
+        session.setAttribute("authProvider", authProvider); // 세션에 인증 제공자 저장
+
+        // 요청 헤더에서 Accept 타입 확인 (AJAX 요청인지 일반 요청인지 판단)
+        String acceptHeader = request.getHeader("Accept"); // Accept 헤더 확인
+        boolean isAjaxRequest = acceptHeader != null && acceptHeader.contains("application/json"); // JSON 요청인지 확인
+
+        // 홈페이지로 리다이렉트 (로그인된 사용자는 홈페이지로)
+        String redirectUrl = "http://localhost:8090/"; // 홈페이지로 리다이렉션
+        getRedirectStrategy().sendRedirect(request, response, redirectUrl); // 리다이렉션 전송
+    }
+
+    /**
+     * 성공 응답 전송 (JSON 형태)
+     * CustomOAuth2UserService에서 처리된 사용자 정보를 JSON으로 변환하여 전송
+     *
+     * @param response HTTP 응답 객체
+     * @param attributes OAuth2User의 속성 정보 (사용자 정보 포함)
+     */
+    private void sendSuccessResponse(HttpServletResponse response, Map<String, Object> attributes) throws IOException { // IO 예외를 던질 수 있음
+        response.setContentType("application/json;charset=UTF-8"); // JSON 응답 타입 설정
+        response.setStatus(HttpServletResponse.SC_OK); // 200 OK 상태 코드 설정
+
+        // 성공 응답 데이터 생성
+        Map<String, Object> successResponse = Map.of( // Map.of를 사용하여 불변 Map 생성
+                "success", true, // 성공 상태
+                "message", "소셜 로그인이 성공했습니다.", // 성공 메시지
+                "user", Map.of( // 사용자 정보
+                        "id", attributes.get("userId"), // 사용자 ID
+                        "email", attributes.get("userEmail"), // 사용자 이메일
+                        "name", attributes.get("userName"), // 사용자 이름
+                        "role", attributes.get("userRole"), // 사용자 권한
+                        "authProvider", attributes.get("authProvider") // 인증 제공자
+                )
+        );
+
+        // JSON 문자열로 변환하여 응답 전송
+        String jsonResponse = objectMapper.writeValueAsString(successResponse); // Map을 JSON 문자열로 변환
+        response.getWriter().write(jsonResponse); // 응답에 JSON 문자열 작성
+    }
+}

--- a/backend/src/main/java/com/ottproject/ottbackend/repository/UserRepository.java
+++ b/backend/src/main/java/com/ottproject/ottbackend/repository/UserRepository.java
@@ -1,6 +1,7 @@
 package com.ottproject.ottbackend.repository;
 
 import com.ottproject.ottbackend.entity.User;
+import com.ottproject.ottbackend.enums.AuthProvider;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -17,7 +18,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
     // 로그인할 때 사용자 정보 조회 ex) 사용자가 로그인 시도 -> 이메일로 사용자 찾기
     boolean existsByEmail (String email); // 이메일 존재 여부 확인
     // 회원가입할 때 이메일 중복 확인 ex) -> 새 사용자가 회원가입 -> 이미 가입된 이메일인지 확인
-    Optional<User> findByEmailAndAuthProvider(String email, String authProvider); // 이메일과 인증 제공자로 사용자 조회 (소셜 로그인용)
+    Optional<User> findByEmailAndAuthProvider(String email, AuthProvider authProvider); // 이메일과 인증 제공자로 사용자 조회 (소셜 로그인용)
     // 소셜 로그인할 때 사용 ex) 구글로 로그인한 사용자가 네이버로도 같은 이메일로 가입하려고 할 때 구분
     List<User> findByEmailVerified(boolean emailVerified); // 이메일 인증 여부로 사용자 조회
     // 관리자 기능 또는 이메일 인증 관리 ex) 관리자가 인증되지 않은 사용자 목록 조회

--- a/backend/src/main/java/com/ottproject/ottbackend/service/CustomOAuth2UserService.java
+++ b/backend/src/main/java/com/ottproject/ottbackend/service/CustomOAuth2UserService.java
@@ -1,0 +1,311 @@
+package com.ottproject.ottbackend.service;
+
+import com.ottproject.ottbackend.entity.User;
+import com.ottproject.ottbackend.enums.AuthProvider;
+import com.ottproject.ottbackend.enums.UserRole;
+import com.ottproject.ottbackend.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * OAuth2 사용자 정보를 처리하는 커스텀 서비스
+ * 소셜 로그인 제공자로부터 받은 사용자 정보를 처리하고
+ * 애플리케이션에서 사용할 수 있는 형태로 변환
+ *
+ * 주요 기능:
+ * 1. 소셜 로그인 제공자별 사용자 정보 처리
+ * 2. 기존 사용자 조회 또는 신규 사용자 생성
+ * 3. OAuth2User 객체 생성 및 반환
+ */
+@Slf4j // Lombok 로깅 어노테이션 - log 객체 자동 생성
+@Service // Spring Bean으로 등록
+@RequiredArgsConstructor // final 필드에 대한 생성자 자동 생성
+public class CustomOAuth2UserService extends DefaultOAuth2UserService { // DefaultOAuth2UserService 를 상속받아 커스터마이징
+
+    private final UserRepository userRepository; // 사용자 Repository 주입 (final 로 선언하여 생성자 주입)
+
+    /**
+     * OAuth2 사용자 정보를 로드하고 처리하는 메서드
+     * 소셜 로그인 제공자로부터 받은 사용자 정보를 처리하여
+     * 애플리케이션에서 사용할 수 있는 형태로 변환
+     *
+     * @param userRequest OAuth2 사용자 요청 정보
+     * @return 처리된 OAuth2User 객체
+     * @throws OAuth2AuthenticationException OAuth2 인증 예외
+     */
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException { // OAuth2 인증 예외를 던질 수 있음
+        try {
+            log.info("OAuth2 사용자 정보 로드 시작 - Provider: {}", userRequest.getClientRegistration().getRegistrationId()); // 로그 출력 - 요청 시작을 알림
+
+            // 기본 OAuth2UserService를 통해 사용자 정보 로드
+            OAuth2User oAuth2User = super.loadUser(userRequest); // 부모 클래스의 loadUser 메서드 호출하여 기본 사용자 정보 로드
+            log.info("OAuth2 사용자 정보 로드 완료 - Attributes: {}", oAuth2User.getAttributes()); // 로그 출력 - 받은 정보 확인
+
+            // 소셜 로그인 제공자 정보 추출
+            String provider = userRequest.getClientRegistration().getRegistrationId(); // 등록된 클라이언트 ID (google, kakao, naver)
+            AuthProvider authProvider = AuthProvider.valueOf(provider.toUpperCase()); // String 을 enum 으로 변환 (GOOGLE, KAKAO, NAVER)
+
+            // OAuth2 사용자 정보에서 필요한 데이터 추출
+            // 각 소셜 로그인 제공자의 응답 구조가 다르므로 제공자별로 처리
+            String email = extractEmail(oAuth2User.getAttributes(), provider); // 이메일 추출
+            String name = extractName(oAuth2User.getAttributes(), provider); // 이름 추출
+            String providerId = extractProviderId(oAuth2User.getAttributes(), provider); // 소셜 로그인 제공자에서의 고유 ID 추출
+
+            // 추출된 정보를 로그로 출력
+            log.info("OAuth2 사용자 정보 추출 - Email: {}, Name: {}, Provider: {}", email, name, providerId); // 로그 출력 - 추출된 정보 확인
+
+            // 사용자 정보 처리 (기존 사용자 조회 또는 신규 사용자 생성)
+            // 같은 이메일이라도 다른 소셜 로그인으로 가입한 경우를 구분하기 위해 인증 제공자도 함께 확인
+            User user = processOAuth2User(email, name, providerId, authProvider); // 사용자 정보 처리 메서드 호출
+
+            // OAuth2User 객체 생성 및 반환 (Spring Security에서 사용할 수 있는 형태로 반환)
+            return createOAuth2User(oAuth2User, user); // OAuth2User 객체 생성 메서드 호출
+
+        } catch (Exception e) {
+            log.error("OAuth2 사용자 정보 로드 중 오류 발생 - Provider: {}, Error: {}",
+                    userRequest.getClientRegistration().getRegistrationId(), e.getMessage(), e); // 에러 로그 출력
+            throw e; // 예외를 다시 던져서 OAuth2FailureHandler에서 처리하도록 함
+        }
+    }
+
+    /**
+     * 소셜 로그인 제공자별 이메일 추출
+     * 각 소셜 로그인 제공자의 응답 구조가 다르므로 제공자별로 처리
+     *
+     * @param attributes 소셜 로그인 제공자에서 받은 사용자 정보 (Map 형태)
+     * @param provider 소셜 로그인 제공자 (google, kakao, naver)
+     * @return 추출된 이메일
+     */
+    private String extractEmail(Map<String, Object> attributes, String provider) { // private 메서드 - 클래스 내부에서만 사용
+        try {
+            switch (provider.toLowerCase()) { // 소셜 로그인 제공자를 소문자로 변환하여 비교
+                case "google": // Google 의 경우
+                    String email = (String) attributes.get("email"); // Google 은 바로 email 필드에 이메일이 있음
+                    if (email == null) { // 이메일이 null인 경우 처리
+                        log.warn("Google에서 이메일 정보를 받지 못했습니다."); // 경고 로그 출력
+                        return "google_" + attributes.get("sub") + "@temp.com"; // 임시 이메일 생성
+                    }
+                    return email; // 정상적인 이메일 반환
+                case "kakao": // Kakao 의 경우
+                    Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account"); // Kakao는 kakao_account 안의 email 필드에서 이메일 추출
+                    if (kakaoAccount == null) { // kakao_account가 null인 경우 처리
+                        log.warn("Kakao에서 kakao_account 정보를 받지 못했습니다."); // 경고 로그 출력
+                        return "kakao_" + attributes.get("id") + "@temp.com"; // 임시 이메일 생성
+                    }
+                    String kakaoEmail = (String) kakaoAccount.get("email"); // kakao_account 에서 email 필드 추출
+                    if (kakaoEmail == null) { // 이메일이 null인 경우 처리
+                        log.warn("Kakao에서 이메일 정보를 받지 못했습니다."); // 경고 로그 출력
+                        return "kakao_" + attributes.get("id") + "@temp.com"; // 임시 이메일 생성
+                    }
+                    return kakaoEmail; // 정상적인 이메일 반환
+                case "naver": // Naver의 경우
+                    Map<String, Object> response = (Map<String, Object>) attributes.get("response"); // Naver 는 response 객체 안에 정보가 있음
+                    if (response == null) { // response가 null인 경우 처리
+                        log.warn("Naver에서 response 정보를 받지 못했습니다."); // 경고 로그 출력
+                        return "naver_" + System.currentTimeMillis() + "@temp.com"; // 임시 이메일 생성
+                    }
+                    String naverEmail = (String) response.get("email"); // response 안의 email 필드에서 이메일 추출
+                    if (naverEmail == null) { // 이메일이 null인 경우 처리
+                        log.warn("Naver에서 이메일 정보를 받지 못했습니다."); // 경고 로그 출력
+                        return "naver_" + response.get("id") + "@temp.com"; // 임시 이메일 생성
+                    }
+                    return naverEmail; // 정상적인 이메일 반환
+                default: // 지원하지 않는 소셜 로그인 제공자인 경우
+                    throw new IllegalArgumentException("지원하지 않는 소셜 로그인 제공자: " + provider); // 예외 발생
+            }
+        } catch (Exception e) {
+            log.error("이메일 추출 중 오류 발생 - Provider: {}, Error: {}", provider, e.getMessage()); // 에러 로그 출력
+            return provider + "_" + System.currentTimeMillis() + "@temp.com"; // 임시 이메일 생성
+        }
+    }
+
+    /**
+     * 소셜 로그인 제공자별 이름 추출
+     * 각 소셜 로그인 제공자의 응답 구조가 다르므로 제공자별로 처리
+     *
+     * @param attributes 소셜 로그인 제공자에서 받은 사용자 정보 (Map 형태)
+     * @param provider 소셜 로그인 제공자 (google, kakao, naver)
+     * @return 추출된 이름
+     */
+    private String extractName(Map<String, Object> attributes, String provider) { // private 메서드 - 클래스 내부에서만 사용
+        try {
+            switch (provider.toLowerCase()) { // 소셜 로그인 제공자를 소문자로 변환하여 비교
+                case "google": // Google 의 경우
+                    String name = (String) attributes.get("name"); // Google 은 바로 name 필드에 이름이 있음
+                    if (name == null) { // 이름이 null인 경우 처리
+                        log.warn("Google에서 이름 정보를 받지 못했습니다."); // 경고 로그 출력
+                        return "Google User"; // 기본 이름 반환
+                    }
+                    return name; // 정상적인 이름 반환
+                case "kakao": // Kakao 의 경우
+                    Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account"); // Kakao 는 kakao_account 객체 안에 정보가 있음
+                    if (kakaoAccount == null) { // kakao_account가 null인 경우 처리
+                        log.warn("Kakao에서 kakao_account 정보를 받지 못했습니다."); // 경고 로그 출력
+                        return "Kakao User"; // 기본 이름 반환
+                    }
+                    Map<String, Object> profile = (Map<String, Object>) kakaoAccount.get("profile"); // kakao_account 안의 profile 객체에서 프로필 정보 가져옴
+                    if (profile == null) { // profile이 null인 경우 처리
+                        log.warn("Kakao에서 profile 정보를 받지 못했습니다."); // 경고 로그 출력
+                        return "Kakao User"; // 기본 이름 반환
+                    }
+                    String nickname = (String) profile.get("nickname"); // profile 안의 nickname 필드에서 이름 추출 (Kakao 는 nickname 을 사용)
+                    if (nickname == null) { // nickname이 null인 경우 처리
+                        log.warn("Kakao에서 nickname 정보를 받지 못했습니다."); // 경고 로그 출력
+                        return "Kakao User"; // 기본 이름 반환
+                    }
+                    return nickname; // 정상적인 이름 반환
+                case "naver": // Naver 의 경우
+                    Map<String, Object> response = (Map<String, Object>) attributes.get("response"); // Naver 는 response 객체 안에 정보가 있음
+                    if (response == null) { // response가 null인 경우 처리
+                        log.warn("Naver에서 response 정보를 받지 못했습니다."); // 경고 로그 출력
+                        return "Naver User"; // 기본 이름 반환
+                    }
+                    String naverName = (String) response.get("name"); // response 안의 name 필드에서 이름 추출
+                    if (naverName == null) { // 이름이 null인 경우 처리
+                        log.warn("Naver에서 이름 정보를 받지 못했습니다."); // 경고 로그 출력
+                        return "Naver User"; // 기본 이름 반환
+                    }
+                    return naverName; // 정상적인 이름 반환
+                default: // 지원하지 않는 소셜 로그인 제공자인 경우
+                    throw new IllegalArgumentException("지원하지 않는 소셜 로그인 제공자: " + provider); // 예외 발생
+            }
+        } catch (Exception e) {
+            log.error("이름 추출 중 오류 발생 - Provider: {}, Error: {}", provider, e.getMessage()); // 에러 로그 출력
+            return provider + " User"; // 기본 이름 반환
+        }
+    }
+
+    /**
+     * 소셜 로그인 제공자별 ID 추출
+     * 각 소셜 로그인 제공자의 응답 구조가 다르므로 제공자별로 처리
+     *
+     * @param attributes 소셜 로그인 제공자에서 받은 사용자 정보 (Map 형태)
+     * @param provider 소셜 로그인 제공자 (google, kakao, naver)
+     * @return 추출된 소셜 로그인 제공자에서의 고유 ID
+     */
+    private String extractProviderId(Map<String, Object> attributes, String provider) { // private 메서드 - 클래스 내부에서만 사용
+        try {
+            switch (provider.toLowerCase()) { // 소셜 로그인 제공자를 소문자로 변환하여 비교
+                case "google": // Google 의 경우
+                    String sub = (String) attributes.get("sub"); // Google 은 sub 필드에 고유 ID가 있음 (subject 의 줄임말)
+                    if (sub == null) { // sub가 null인 경우 처리
+                        log.warn("Google에서 sub 정보를 받지 못했습니다."); // 경고 로그 출력
+                        return "google_" + System.currentTimeMillis(); // 임시 ID 생성
+                    }
+                    return sub; // 정상적인 ID 반환
+                case "kakao": // Kakao 의 경우
+                    Object id = attributes.get("id"); // Kakao 는 id 필드에 고유 ID가 있음 (Long 타입이므로 String 으로 변환)
+                    if (id == null) { // id가 null인 경우 처리
+                        log.warn("Kakao에서 id 정보를 받지 못했습니다."); // 경고 로그 출력
+                        return "kakao_" + System.currentTimeMillis(); // 임시 ID 생성
+                    }
+                    return String.valueOf(id); // String으로 변환하여 반환
+                case "naver": // Naver 의 경우
+                    Map<String, Object> response = (Map<String, Object>) attributes.get("response"); // Naver 는 response 객체 안에 정보가 있음
+                    if (response == null) { // response가 null인 경우 처리
+                        log.warn("Naver에서 response 정보를 받지 못했습니다."); // 경고 로그 출력
+                        return "naver_" + System.currentTimeMillis(); // 임시 ID 생성
+                    }
+                    String naverId = (String) response.get("id"); // response 안의 id 필드에서 고유 ID 추출
+                    if (naverId == null) { // id가 null인 경우 처리
+                        log.warn("Naver에서 id 정보를 받지 못했습니다."); // 경고 로그 출력
+                        return "naver_" + System.currentTimeMillis(); // 임시 ID 생성
+                    }
+                    return naverId; // 정상적인 ID 반환
+                default: // 지원하지 않는 소셜 로그인 제공자인 경우
+                    throw new IllegalArgumentException("지원하지 않는 소셜 로그인 제공자: " + provider); // 예외 발생
+            }
+        } catch (Exception e) {
+            log.error("ID 추출 중 오류 발생 - Provider: {}, Error: {}", provider, e.getMessage()); // 에러 로그 출력
+            return provider + "_" + System.currentTimeMillis(); // 임시 ID 생성
+        }
+    }
+
+    /**
+     * OAuth2 사용자 정보 처리 (기존 사용자 조회 또는 신규 사용자 생성)
+     * 같은 이메일로 다른 소셜 로그인 제공자로 가입한 경우를 처리
+     *
+     * @param email 사용자 이메일
+     * @param name 사용자 이름
+     * @param providerId 소셜 로그인 제공자에서의 고유 ID
+     * @param authProvider 인증 제공자 (GOOGLE, KAKAO, NAVER)
+     * @return 처리된 사용자 정보 (기존 사용자 또는 신규 생성된 사용자)
+     */
+    private User processOAuth2User(String email, String name, String providerId, AuthProvider authProvider) {
+        // 먼저 이메일로만 사용자 조회
+        Optional<User> existingUserByEmail = userRepository.findByEmail(email);
+        
+        if (existingUserByEmail.isPresent()) { // 같은 이메일로 가입된 사용자가 존재하는 경우
+            User existingUser = existingUserByEmail.get();
+            
+            // 같은 인증 제공자로 가입된 경우 - 기존 사용자 정보 업데이트
+            if (existingUser.getAuthProvider() == authProvider) {
+                existingUser.setName(name); // 이름 업데이트
+                existingUser.setProviderId(providerId); // 소셜 로그인 ID 업데이트
+                existingUser.setEmailVerified(true); // 소셜 로그인은 이메일 인증 완료로 간주
+                return userRepository.save(existingUser); // 업데이트된 사용자 정보를 DB에 저장
+            } else {
+                // 다른 인증 제공자로 가입된 경우 - 기존 사용자의 인증 제공자 정보 업데이트
+                log.info("기존 사용자가 다른 인증 제공자로 가입되어 있음 - Email: {}, 기존 Provider: {}, 새 Provider: {}", 
+                        email, existingUser.getAuthProvider(), authProvider);
+                
+                existingUser.setAuthProvider(authProvider); // 인증 제공자 변경
+                existingUser.setProviderId(providerId); // 소셜 로그인 ID 업데이트
+                existingUser.setName(name); // 이름 업데이트
+                existingUser.setEmailVerified(true); // 소셜 로그인은 이메일 인증 완료로 간주
+                return userRepository.save(existingUser); // 업데이트된 사용자 정보를 DB에 저장
+            }
+        } else { // 같은 이메일로 가입된 사용자가 존재하지 않는 경우 (신규 사용자)
+            // 신규 사용자 생성 (빌더 패턴 사용)
+            User newUser = User.builder() // User 빌더 시작
+                    .email(email) // 이메일 설정
+                    .name(name) // 이름 설정
+                    .authProvider(authProvider) // 인증 제공자 설정
+                    .providerId(providerId) // 소셜 로그인 제공자에서의 고유 ID 설정
+                    .emailVerified(true) // 소셜 로그인은 이메일 인증 완료로 간주
+                    .enabled(true) // 계정 활성화 상태로 설정
+                    .role(UserRole.USER) // 사용자 역할 설정 (USER 로 기본 설정)
+                    .build(); // User 객체 생성 완료
+
+            return userRepository.save(newUser); // 신규 사용자를 DB에 저장
+        }
+    }
+
+    /**
+     * OAuth2User 객체 생성
+     * Spring Security 에서 사용할 수 있는 형태로 OAuth2User 객체를 생성
+     * 기존 OAuth2User 의 정보에 애플리케이션에서 추가한 사용자 정보를 포함
+     *
+     * @param oAuth2User 소셜 로그인 제공자로부터 받은 원본 OAuth2User 객체
+     * @param user 애플리케이션에서 처리한 사용자 정보
+     * @return Spring Security 에서 사용할 수 있는 OAuth2User 객체
+     */
+    private OAuth2User createOAuth2User(OAuth2User oAuth2User, User user) {
+        // 기존 OAuth2User 의 attributes 에 사용자 정보 추가
+        // 소셜 로그인 제공자로부터 받은 정보 + 애플리케이션에서 추가한 정보를 모두 포함
+        Map<String, Object> attributes = new HashMap<>(oAuth2User.getAttributes()); // 원본 attributes 복사
+        attributes.put("userId", user.getId()); // 애플리케이션에서의 사용자 ID 추가
+        attributes.put("userEmail", user.getEmail()); // 사용자 이메일 추가
+        attributes.put("userName", user.getName()); // 사용자 이름 추가
+        attributes.put("userRole", user.getRole().name()); // 사용자 권한 추가 (USER, ADMIN 등)
+        attributes.put("authProvider", user.getAuthProvider().name()); // 인증 제공자 정보 추가
+
+        // 새로운 OAuth2User 객체 생성 및 반환
+        // Spring Security에서 사용할 수 있는 DefaultOAuth2User 객체 생성
+        return new org.springframework.security.oauth2.core.user.DefaultOAuth2User(
+                oAuth2User.getAuthorities(), // 기존 권한 정보 (소셜 로그인 제공자에서 받은 권한)
+                attributes, // 사용자 속성 정보 (소셜 로그인 정보 + 애플리케이션 정보)
+                "userEmail" // nameAttributeKey - Spring Security 에서 사용자 식별에 사용할 키 (이메일 사용)
+        );
+    }
+}

--- a/backend/src/main/java/com/ottproject/ottbackend/service/CustomUserDetailsService.java
+++ b/backend/src/main/java/com/ottproject/ottbackend/service/CustomUserDetailsService.java
@@ -3,6 +3,7 @@ package com.ottproject.ottbackend.service;
 import com.ottproject.ottbackend.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import com.ottproject.ottbackend.entity.User;
+import com.ottproject.ottbackend.enums.AuthProvider;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
@@ -23,11 +24,14 @@ public class CustomUserDetailsService  implements UserDetailsService { // spring
         User user = userRepository.findByEmail(email) // DB 에서 이메일로 사용자 검색
                 .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다: " + email));
 
-        // UserDetail 객체 생성 및 반환 (빌대 퍼탠 사용)
+        // 소셜 로그인 사용자인지 확인 (소셜 로그인 사용자는 비밀번호가 null)
+        boolean isSocialUser = user.getAuthProvider() != AuthProvider.LOCAL; // LOCAL이 아닌 경우 소셜 로그인 사용자
+
+        // UserDetail 객체 생성 및 반환 (빌더 패턴 사용)
         return org.springframework.security.core.userdetails.User.builder()
                 .username(user.getEmail()) // spring security 에서 사용할 사용자명 (이메일 사용)
-                .password(user.getPassword()) // 암호화된 비밀번호 ( 자동 검증
-                .disabled(!user.isEnabled()) // 계정 비활성화 여부 (User 엔티티의 enbled 의 반대값)
+                .password(isSocialUser ? "{noop}" + (user.getPassword() != null ? user.getPassword() : "") : user.getPassword()) // 소셜 로그인 사용자는 {noop} 접두사로 비밀번호 검증 건너뛰기, 자체 로그인 사용자는 암호화된 비밀번호 사용
+                .disabled(!user.isEnabled()) // 계정 비활성화 여부 (User 엔티티의 enabled 의 반대값)
                 .accountExpired(false) // 계정 만료 여부 (false:만료되지 않음)
                 .credentialsExpired(false) // 자격 증명 만료 여부 (false:만료되지 않음)
                 .accountLocked(false) // 계정 잠금 여부 (false: 잠금되지 않음)

--- a/backend/src/main/java/com/ottproject/ottbackend/service/EmailService.java
+++ b/backend/src/main/java/com/ottproject/ottbackend/service/EmailService.java
@@ -15,7 +15,7 @@ public class EmailService {
 
     private final JavaMailSender mailSender; // spring boot mail 자동 주입 (SMTP 서버 연결용)
 
-    @Value("${spring.mail.username}") // application.yml 에서 발신자 이메일 주소 주입
+    @Value("${spring.mail.username}") // application-dev.yml 에서 발신자 이메일 주소 주입
     private String fromEmail;
 
     // 임시 저장소 (실제로는 Redis 사용 권장) - 인증 코드와 이메일 매핑

--- a/backend/src/main/java/com/ottproject/ottbackend/service/UserService.java
+++ b/backend/src/main/java/com/ottproject/ottbackend/service/UserService.java
@@ -1,6 +1,7 @@
 package com.ottproject.ottbackend.service;
 
 import com.ottproject.ottbackend.entity.User;
+import com.ottproject.ottbackend.enums.AuthProvider;
 import com.ottproject.ottbackend.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -45,5 +46,18 @@ public class UserService {
     public User updateUser(User user) { // 사용자 정보 업데이트
         return userRepository.save(user); // 기존 사용자 정보를 새로운 정보로 업데이트
         // JPA 의 save 메서드는 ID가 있으면 update, 없으면 insert 수행
+    }
+
+    /**
+     * 이메일과 인증 제공자로 사용자 조회 (소셜 로그인용)
+     * 같은 이메일이라도 다른 소셜 로그인으로 가입한 경우를 구분하기 위해 사용
+     *
+     * @param email 사용자 이메일
+     * @param authProvider 인증 제공자 (GOOGLE, KAKAO, NAVER, LOCAL)
+     * @return 사용자 정보 (Optional)
+     */
+    @Transactional(readOnly = true) // 읽기 전용 트랜잭션 (성능 최적화)
+    public Optional<User> findByEmailAndAuthProvider(String email, AuthProvider authProvider) {
+        return userRepository.findByEmailAndAuthProvider(email, authProvider); // Repository 메서드 호출
     }
 }


### PR DESCRIPTION
feat: implement OAuth2 social login with multiple providers

- Add OAuth2 support for Kakao, Naver, and Google login
- Implement CustomOAuth2UserService with duplicate email handling
- Add OAuth2 API endpoints for user info, status, and logout
- Create custom OAuth2SuccessHandler and OAuth2FailureHandler
- Handle duplicate email scenarios when users sign up with different providers
- Add comprehensive OAuth2 controller with login URLs and user management
- Update User entity with @Builder.Default annotations for proper builder pattern
- Configure Spring Security for OAuth2 authentication flow

Resolves duplicate key constraint violations for users with same email across providers