### PR TITLE
Feat/review comment logic

### DIFF
--- a/backend/src/main/java/com/ottproject/ottbackend/controller/CommentController.java
+++ b/backend/src/main/java/com/ottproject/ottbackend/controller/CommentController.java
@@ -17,13 +17,14 @@ public class CommentController { // 댓글 목록/대댓글/작성/상태변경/
 
     @GetMapping // gET /api/reviews/{reviewId}/comments
     public ResponseEntity<PagedResponse<CommentResponseDto>> listByReview( // 최상위 댓글 목록(페이지네이션)
-            @PathVariable Long reviewId, // 경러변수: 리뷰 ID
+            @PathVariable Long reviewId, // 경로변수: 리뷰 ID
             @RequestParam(required = false) Long currentUserId, // 선택: 현재 사용자 ID(좋아요 여부 계산용)
             @RequestParam(defaultValue = "0") int page, // 페이지 번호(0-base)
-            @RequestParam(defaultValue = "10") int size // 페이지 크기
+            @RequestParam(defaultValue = "10") int size, // 페이지 크기
+            @RequestParam(defaultValue = "latest") String sort // latest|best
     ) {
         return ResponseEntity.ok( // 200 OK
-                commentService.listByReview(reviewId, currentUserId, page, size) // 서비스 위임
+                commentService.listByReview(reviewId, currentUserId, page, size, sort) // 서비스 위임
         );
     }
 

--- a/backend/src/main/java/com/ottproject/ottbackend/dto/CreateReviewRequestDto.java
+++ b/backend/src/main/java/com/ottproject/ottbackend/dto/CreateReviewRequestDto.java
@@ -1,5 +1,6 @@
 package com.ottproject.ottbackend.dto;
 
+import com.ottproject.ottbackend.validation.ContentOrRatingRequired;
 import com.ottproject.ottbackend.validation.HalfStep;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.DecimalMax;
@@ -18,6 +19,7 @@ import lombok.*;
 @NoArgsConstructor // 기본 생성자
 @AllArgsConstructor // 전체 필드 생성자
 @Valid
+@ContentOrRatingRequired
 public class CreateReviewRequestDto {
 
     @NotNull(message = "aniId는 필수입니다.") // 필수 값

--- a/backend/src/main/java/com/ottproject/ottbackend/dto/UpdateReviewRequestDto.java
+++ b/backend/src/main/java/com/ottproject/ottbackend/dto/UpdateReviewRequestDto.java
@@ -1,5 +1,7 @@
 package com.ottproject.ottbackend.dto;
 
+import com.ottproject.ottbackend.validation.ContentOrRatingRequired;
+import com.ottproject.ottbackend.validation.HalfStep;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.DecimalMax;
 import jakarta.validation.constraints.DecimalMin;
@@ -16,6 +18,7 @@ import lombok.*;
 @NoArgsConstructor // 기본 생성자
 @AllArgsConstructor // 전체 필드 생성자
 @Valid
+@ContentOrRatingRequired
 public class UpdateReviewRequestDto {
 
     @Size(max = 1000, message = "내용은 최대 1000자입니다.")
@@ -23,5 +26,6 @@ public class UpdateReviewRequestDto {
 
     @DecimalMin(value = "0.5", message = "평정믄 0.5 이상이어야 합니다.")
     @DecimalMax(value = "5.0", message = "평점은 5.0 이하여야 합니다.")
+    @HalfStep
     private Double rating; // 수정할 평점(선택)
 }

--- a/backend/src/main/java/com/ottproject/ottbackend/entity/CommentLike.java
+++ b/backend/src/main/java/com/ottproject/ottbackend/entity/CommentLike.java
@@ -12,7 +12,10 @@ import java.time.LocalDateTime;
  * 사용자와 댓글 간의 좋아요 관계를 관리하며, 중복 좋아요를 방지합니다.
  */
 @Entity
-@Table(name = "comment_likes")
+@Table( // 테이블 매핑
+        name = "comment_likes", // 테이블명
+        uniqueConstraints = @UniqueConstraint(columnNames = {"user_id","comment_id"}) // 복합 유니크
+) // 유니크로 동일 사용자 중복 방지
 @Getter
 @Setter
 @Builder
@@ -37,10 +40,4 @@ public class CommentLike  {
     @ManyToOne(fetch = FetchType.LAZY) // 다대일 관계, 지연 로딩으로 성능 최적화
     @JoinColumn(name = "comment_id", nullable = false) // 외래키 설정
     private Comment comment; // 좋아요가 달린 댓글 (다대일 관계 - 여러 좋아요 레코드가 하나의 댓글을 참조)
-
-    // 복합 유니크 제약 조건 (한 사용자가 한 댓글에 좋아요를 한 번만 누를 수 있음)
-    @Table(uniqueConstraints = {
-            @UniqueConstraint(columnNames = {"user_id", "comment_id"})
-    })
-    public static class CommentLikeTable {}
 }

--- a/backend/src/main/java/com/ottproject/ottbackend/entity/ReviewLike.java
+++ b/backend/src/main/java/com/ottproject/ottbackend/entity/ReviewLike.java
@@ -12,13 +12,16 @@ import java.time.LocalDateTime;
  * 사용자와 리뷰 간의 좋아요 관계를 관리하며, 중복 좋아요를 방지합니다.
  */
 @Entity
-@Table(name = "review_likes")
+@Table( // 테이블 매핑
+        name = "review_likes", // 테이블명
+        uniqueConstraints = @UniqueConstraint(columnNames = {"user_id","review_id"}) // 복합 유니크(중복 방지)
+) // 엔티티 레벨에서 유니크 선언(중요)
 @Getter
 @Setter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@EntityListeners(AuditingEntityListener.class)
+@EntityListeners(AuditingEntityListener.class) // 생성일시 자동 주입
 public class ReviewLike {
     @Id // 기본키 지정
     @GeneratedValue(strategy = GenerationType.IDENTITY) // 자동 증가 전략
@@ -36,10 +39,4 @@ public class ReviewLike {
     @ManyToOne(fetch = FetchType.LAZY) // 다대일 관계, 지연 로딩
     @JoinColumn(name = "review_id", nullable = false) // 외래키 설정
     private Review review; // 좋아요가 달린 리뷰 (다대일 관계 - 여러 좋아요 레코드가 하나의 리뷰를 참조)
-
-    // 복합 유니크 제약 조건(한 사용자가 한 리뷰에 좋아요를 한 번만 누를 수 있음)
-    @Table(uniqueConstraints = {
-            @UniqueConstraint(columnNames = {"user_id", "review_id"})
-    })
-    public static class ReviewLikeTable {}
 }

--- a/backend/src/main/java/com/ottproject/ottbackend/mybatis/ReviewCommentQueryMapper.java
+++ b/backend/src/main/java/com/ottproject/ottbackend/mybatis/ReviewCommentQueryMapper.java
@@ -35,6 +35,7 @@ public interface ReviewCommentQueryMapper {
     List<CommentResponseDto> findCommentsByReviewId(
             @Param("reviewId") Long reviewId, // 대상 리뷰 ID
             @Param("currentUserId") Long currentUserId, // 현재 사용자 ID
+            @Param("sort") String sort, // 정렬 latest|best
             @Param("limit") int limit, // 페이지 크기
             @Param("offset") int offset // 오프셋
     );

--- a/backend/src/main/java/com/ottproject/ottbackend/repository/CommentLikeRepository.java
+++ b/backend/src/main/java/com/ottproject/ottbackend/repository/CommentLikeRepository.java
@@ -1,0 +1,9 @@
+package com.ottproject.ottbackend.repository;
+import com.ottproject.ottbackend.entity.CommentLike;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository // 빈 등록
+public interface CommentLikeRepository extends JpaRepository<CommentLike, Long> { // CUD 전용
+    int deleteByUserIdAndCommentId(Long userId, Long commentId); // 토글 off 용 삭제(CUD)
+}

--- a/backend/src/main/java/com/ottproject/ottbackend/repository/ReviewLikeRepository.java
+++ b/backend/src/main/java/com/ottproject/ottbackend/repository/ReviewLikeRepository.java
@@ -1,0 +1,9 @@
+package com.ottproject.ottbackend.repository;
+import com.ottproject.ottbackend.entity.ReviewLike;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository // 빈 등록
+public interface ReviewLikeRepository extends JpaRepository<ReviewLike, Long> { // CUD 전용
+    int deleteByUserIdAndReviewId(Long userId, Long reviewId); // 토글 off 용 삭제(CUD)
+}

--- a/backend/src/main/java/com/ottproject/ottbackend/service/CommentService.java
+++ b/backend/src/main/java/com/ottproject/ottbackend/service/CommentService.java
@@ -3,14 +3,17 @@ package com.ottproject.ottbackend.service;
 import com.ottproject.ottbackend.dto.CommentResponseDto;
 import com.ottproject.ottbackend.dto.PagedResponse;
 import com.ottproject.ottbackend.entity.Comment;
+import com.ottproject.ottbackend.entity.CommentLike;
 import com.ottproject.ottbackend.entity.Review;
 import com.ottproject.ottbackend.entity.User;
 import com.ottproject.ottbackend.enums.CommentStatus;
 import com.ottproject.ottbackend.mybatis.ReviewCommentQueryMapper;
+import com.ottproject.ottbackend.repository.CommentLikeRepository;
 import com.ottproject.ottbackend.repository.CommentRepository;
 import com.ottproject.ottbackend.repository.ReviewRepository;
 import com.ottproject.ottbackend.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -27,13 +30,14 @@ public class CommentService {
     private final CommentRepository commentRepository; // 댓글 CUD
     private final ReviewRepository reviewRepository; // 부모 리뷰 검증/연관
     private final UserRepository userRepository; // 작성자 검증/연관
+    private final CommentLikeRepository commentLikeRepository; // 좋아요 CUD
 
     @Transactional(readOnly = true) // 읽기 전용 트랜잭션
     public PagedResponse<CommentResponseDto> listByReview(Long reviewId, Long currentUserId, int page, int size) {
         int limit = size; // LIMIT 계산
         int offset = Math.max(page, 0) * size; // OFFSET 계산(0 미만 보호)
         List<CommentResponseDto> items = commentQueryMapper
-                .findCommentsByReviewId(reviewId, currentUserId, limit, offset);
+                .findCommentsByReviewId(reviewId, currentUserId, "latest", limit, offset);
         long total = commentQueryMapper.countCommentsByReviewId(reviewId); // 총 개수 조회
         return new PagedResponse<>(items, total, page, size); // 표준 페이지 응답
     }
@@ -41,6 +45,16 @@ public class CommentService {
     @Transactional(readOnly = true) // 읽기 전용 트랜잭션
     public List<CommentResponseDto> listReplies(Long parentId, Long currentUserId) {
         return commentQueryMapper.findRepliesByParentId(parentId, currentUserId); // 대댓글 목록
+    }
+
+    @Transactional(readOnly = true) // 읽기 전용 트랜잭션
+    public PagedResponse<CommentResponseDto> listByReview(Long reviewId, Long currentUserId, int page, int size, String sort) { // [NEW]
+        int limit = size; // LIMIT 계산
+        int offset = Math.max(page, 0) * size; // OFFSET 계산(0 미만 보호)
+        List<CommentResponseDto> items = commentQueryMapper
+                .findCommentsByReviewId(reviewId, currentUserId, sort, limit, offset); // [NEW]
+        long total = commentQueryMapper.countCommentsByReviewId(reviewId); // 총 개수 조회
+        return new PagedResponse<>(items, total, page, size); // 표준 페이지 응답
     }
 
     public Long create(Long userId, Long reviewId, Long parentId, String content) {
@@ -68,6 +82,42 @@ public class CommentService {
                 .build();
 
         return commentRepository.save(comment).getId(); // 저장 후 ID 반환
+    }
+
+    public void updateContent(Long commentId, Long userId, String content) { // 본인 댓글 수정
+        Comment comment = commentRepository.findByIdForUpdate(commentId)
+                .orElseThrow(() -> new IllegalArgumentException("comment not found: " + commentId));
+        if (!comment.getUser().getId().equals(userId)) throw new SecurityException("forbidden");
+        comment.setContent(content); // 내용 갱신
+        commentRepository.save(comment); // 저장
+    }
+
+    public void deleteSoft(Long commentId, Long userId) { // 본인 댓글 소프트 삭제(상태 전환)
+        Comment comment = commentRepository.findByIdForUpdate(commentId)
+                .orElseThrow(() -> new IllegalArgumentException("comment not found: " + commentId));
+        if (!comment.getUser().getId().equals(userId)) throw new SecurityException("forbidden"); // 소유자 검증
+        commentRepository.updateStatus(commentId, CommentStatus.DELETED); // 상태 전환
+    }
+
+    public void report(Long commentId, Long userId) { // 댓글 신고(누구나 가능)
+        // 필요 시 사용자 존재만 검증
+        userRepository.findById(userId).orElseThrow(() -> new IllegalArgumentException("user not found: " + userId));
+        commentRepository.updateStatus(commentId, CommentStatus.REPORTED); // 상태 전환
+    }
+
+    public boolean toggleLike(Long commentId, Long userId) { // 좋아요 토글(C/D 만 사용, insert-first 전략)
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("user not found: " + userId));
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new IllegalArgumentException("comment not found: " + commentId));
+        try {
+            commentLikeRepository.save(CommentLike.builder().user(user).comment(comment).build()); // on 시도
+            return true; // on
+        } catch (DataIntegrityViolationException e) {
+            // 이미 on → off
+            commentLikeRepository.deleteByUserIdAndCommentId(userId, commentId); // off
+            return false; // off
+        }
     }
 
     public void updateStatus(Long commentId, CommentStatus status) {

--- a/backend/src/main/resources/mappers/ReviewCommentQueryMapper.xml
+++ b/backend/src/main/resources/mappers/ReviewCommentQueryMapper.xml
@@ -132,7 +132,14 @@
         WHERE c.review_id = #{reviewId}
         AND c.parent_id IS NULL
         AND c.status = 'ACTIVE'
-        ORDER BY c.id ASC
+        <choose>
+            <when test="sort == 'best'">
+                ORDER BY likeCount DESC, c.id DESC
+            </when>
+            <otherwise>
+                ORDER BY c.id DESC
+            </otherwise>
+        </choose>
         LIMIT #{limit} OFFSET #{offset}
     </select>
 


### PR DESCRIPTION
Create a dedicated repository for Like CUD
Add a `sort` query parameter to the comment list and pass it to the service
Add a `sort` parameter to the comment list method (extend the interface signature)
Add a `latest|best` sorting branch (`<choose>`) to the comment list
Modify the `(user_id, comment_id)` composite unique to prevent duplicate post likes to be applied to the `@Table` entity
Modify the `(user_id, review_id)` composite unique to prevent duplicate review likes to be applied to the `@Table` entity
Add a `listByReview(..., sort)` overload and change the default call to delegate to `latest`
: Added self-edit/delete/report/like toggle logic (for JPA CUD only)