### PR TITLE
Feat/review comment logic

### DIFF
--- a/backend/src/main/java/com/ottproject/ottbackend/controller/CommentController.java
+++ b/backend/src/main/java/com/ottproject/ottbackend/controller/CommentController.java
@@ -1,12 +1,17 @@
 package com.ottproject.ottbackend.controller;
 
+import com.ottproject.ottbackend.dto.CreateCommentRequestDto;
 import com.ottproject.ottbackend.dto.CommentResponseDto;
 import com.ottproject.ottbackend.dto.PagedResponse;
+import com.ottproject.ottbackend.dto.UpdateCommentRequestDto;
 import com.ottproject.ottbackend.enums.CommentStatus;
 import com.ottproject.ottbackend.service.CommentService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RequiredArgsConstructor // final 필드 기반 생성자 자동 생성
 @RestController
@@ -15,7 +20,18 @@ public class CommentController { // 댓글 목록/대댓글/작성/상태변경/
 
     private final CommentService commentService; // 댓글 서비스 의존성
 
-    @GetMapping // gET /api/reviews/{reviewId}/comments
+
+    @PostMapping // POST /api/reviews{reviewId}/comments
+    public ResponseEntity<Long> create( // 최상위 댓글 생성
+            @PathVariable Long reviewId, // 경로변수: 리뷰 ID
+			@RequestParam Long userId, // 작성자 ID(인증 연동 전 임시
+			@Valid @RequestBody CreateCommentRequestDto dto // 요청 바디(JSON)로 내용 수신
+    ) {
+		Long id  = commentService.create(userId, reviewId, null, dto.getContent()); // parentId = null(최상위)
+        return ResponseEntity.ok(id); // 200 + 생성 ID
+    }
+
+    @GetMapping // Get /api/reviews/{reviewId}/comments
     public ResponseEntity<PagedResponse<CommentResponseDto>> listByReview( // 최상위 댓글 목록(페이지네이션)
             @PathVariable Long reviewId, // 경로변수: 리뷰 ID
             @RequestParam(required = false) Long currentUserId, // 선택: 현재 사용자 ID(좋아요 여부 계산용)
@@ -30,7 +46,7 @@ public class CommentController { // 댓글 목록/대댓글/작성/상태변경/
 
     @PatchMapping("/{commentId}/status") // PATCH /api/reviews/{reviewId}/comments/{commentId}/status
     public ResponseEntity<Void> updateStatus( // 댓글 상태 변경(소프트 삭제/복구/신고 등)
-            @PathVariable Long reviewId, // 경로변수: 리부ㅠ ID(경로 일관성 유지)
+            @PathVariable Long reviewId, // 경로변수: 리뷰 ID(경로 일관성 유지)
             @PathVariable Long commentId, // 경로변수: 댓글 ID
             @RequestParam CommentStatus status // 쿼리파라미터: 상태 값
 
@@ -46,4 +62,57 @@ public class CommentController { // 댓글 목록/대댓글/작성/상태변경/
         commentService.deleteHardByReview(reviewId); // 일괄 하드 삭제
         return ResponseEntity.noContent().build(); // 204 No Content
     }
+
+    @PutMapping("/api/comments/{commentId}") // 절대 경로: PUT
+    public ResponseEntity<Void> update( // 본인 댓글 수정
+            @PathVariable Long commentId, // 경로변수: 댓글 ID
+            @RequestParam Long userId, // 작성자 ID(인증 연동 전 임시)
+            @Valid @RequestBody UpdateCommentRequestDto dto // 요청바디: 수정 내용
+    ) {
+        commentService.updateContent(commentId, userId, dto.getContent()); // 서비스 위임
+        return ResponseEntity.noContent().build(); // 204 No Content
+    }
+
+    @DeleteMapping("/api/comments/{commentId}") // 절대 경로: DELETE
+    public ResponseEntity<Void> delete( // 본인 댓글 소프트 삭제
+            @PathVariable Long commentId, // 경로변수: 댓글 ID
+            @RequestParam Long userId // 작성자 ID
+    ) {
+        commentService.deleteSoft(commentId, userId); // 상태 DELETED 전환
+        return ResponseEntity.noContent().build(); // 204 No Content
+    }
+
+    @PostMapping("/api/comments/{commentId}/report") // 절대 경로: POST
+    public ResponseEntity<Void> report( // 댓글 신고
+            @PathVariable Long commentId, // 경로변수: 댓글 ID
+            @RequestParam Long userId // 신고자 ID
+    ) {
+        commentService.report(commentId, userId); // t상태 REPORTED 전환
+        return ResponseEntity.noContent().build(); // 204 No Content
+    }
+
+    @PostMapping("/api/comments/{commentId}/like") // 절대 경로 POST
+    public ResponseEntity<Boolean> toggleLike( // 좋아요 토글(true=on, false=off
+            @PathVariable Long commentId, // 경로변수: 댓글 Id
+            @RequestParam Long userId // 사용자 ID
+    ) {
+        return ResponseEntity.ok(commentService.toggleLike(commentId, userId)); // 200 OK + 토글 결과
+    }
+
+    @GetMapping("/api/comments/{commentId}/replies") // 절대 경로: GET
+    public ResponseEntity<List<CommentResponseDto>> replies( // 대댓글 목록(플랫)
+            @PathVariable Long commentId, // 경로변수: 부모댓글 ID
+            @RequestParam(required = false) Long currentUserId // 선택 현재 사용자 ID(좋아요 여부 계산용)
+    ) {
+        return ResponseEntity.ok(commentService.listReplies(commentId, currentUserId)); // 200 OK + 리스트
+    }
+
+	@PostMapping("/api/comments/{commentId}/replies") // 절대 경로: POST
+	public ResponseEntity<Long> createReply( // 대댓글 생성
+			@PathVariable Long commentId, // 경로변수: 부모 댓글 ID
+			@RequestParam Long userId, // 작성자 ID(인증 연동 전 임시)
+			@Valid @RequestBody CreateCommentRequestDto dto // 요청 바디(JSON)
+	) {
+		return ResponseEntity.ok(commentService.createReply(userId, commentId, dto.getContent())); // 200 OK + 생성 ID
+	}
 }

--- a/backend/src/main/java/com/ottproject/ottbackend/controller/ReviewController.java
+++ b/backend/src/main/java/com/ottproject/ottbackend/controller/ReviewController.java
@@ -3,6 +3,7 @@ package com.ottproject.ottbackend.controller;
 import com.ottproject.ottbackend.dto.CreateReviewRequestDto;
 import com.ottproject.ottbackend.dto.PagedResponse;
 import com.ottproject.ottbackend.dto.ReviewResponseDto;
+import com.ottproject.ottbackend.dto.UpdateReviewRequestDto;
 import com.ottproject.ottbackend.service.ReviewService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -50,5 +51,41 @@ public class ReviewController { // 리뷰 목록/작성/일괄삭제 담당 컨�
     ) {
         reviewService.deleteHardByAniList(aniId); // 일괄 하드 삭제
         return ResponseEntity.noContent().build(); // 204 No Content
+    }
+
+    @PutMapping("/api/reviews/{reviewId}") // 절대 경로: PUT
+    public ResponseEntity<Void> update( // 본인 리뷰 수정
+            @PathVariable Long reviewId, // 경로변수: 리뷰 ID
+            @RequestParam Long userId, // 작성자 ID(인증 연동 전 임시
+            @Valid @RequestBody UpdateReviewRequestDto dto // 요청 바디: 수정 필드(content/rating)
+    ) {
+        reviewService.update(reviewId, userId, dto.getContent(), dto.getRating()); // 서비스 위임
+        return ResponseEntity.noContent().build(); // 204 No Content
+    }
+
+    @DeleteMapping("/api/reviews/{reviewId}") // 절대 경로: DELETE
+    public ResponseEntity<Void> delete( // 본인 리뷰 소프트 삭제(상태 전환)
+            @PathVariable Long reviewId, // 경로변수: 리뷰 ID
+            @RequestParam Long userId // 작성자 ID(인증 연동 전 임시)
+    ) {
+        reviewService.deleteSoft(reviewId, userId); // 상태 DELETED 전환
+        return ResponseEntity.noContent().build(); // 204 No Content
+    }
+
+    @PostMapping("/api/reviews/{reviewId}/report") // 절대 경로 Post
+    public ResponseEntity<Void> report( // 리뷰 신고
+            @PathVariable Long reviewId, // 경로변수: 리뷰 ID
+            @RequestParam Long userId // 신고자 ID(인증 연동 전 임시
+    ) {
+        reviewService.report(reviewId, userId); // 상태 REPORTED 전환
+        return ResponseEntity.noContent().build(); // 204 No Content
+    }
+
+    @PostMapping("/api/reviews/{reviewId}/like") // 절대 경로: POST
+    public ResponseEntity<Boolean> toggleLike( // 좋아요 토글(true=on, false=off
+            @PathVariable Long reviewId, // 경로변수: 리뷰 ID
+            @RequestParam Long userId // 사용자 ID(인증 연동 전 임시)
+    ) {
+        return ResponseEntity.ok(reviewService.toggleLike(reviewId, userId)); // 200 OK + 토글 결과
     }
 }

--- a/backend/src/main/java/com/ottproject/ottbackend/dto/CreateCommentRequestDto.java
+++ b/backend/src/main/java/com/ottproject/ottbackend/dto/CreateCommentRequestDto.java
@@ -1,27 +1,20 @@
 package com.ottproject.ottbackend.dto;
 
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
-import lombok.*;
+import lombok.*; // 임포트 라인에는 주석을 달지 않습니다.
 
 /**
  * 댓글 생성 요청 DTO
- * - 리뷰에 대한 댓글 또는 특정 댓글의 대댓글 생성
+ * - 최상위 댓글/대댓글 모두 공통으로 content 만 전달
  */
-@Getter
-@Setter
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
-public class CreateCommentRequestDto {
-
-    @NotNull(message = "reviewId는 필수입니다.")
-    private Long reviewId; // 댓글이 달릴 리뷰 ID
-
-    private Long parentId; // 대댓글이면 부모 댓글 ID(최상위면 null)
-
-    @NotBlank(message = "내용은 필수입니다.")
-    @Size(max = 1000, message = "내용은 최대 1000자 입니다.")
-    private String content; // 댓글 내용
+@Getter // 게터 생성
+@Setter // 세터 생성
+@Builder // 빌더 생성
+@NoArgsConstructor // 기본 생성자
+@AllArgsConstructor // 전체 필드 생성자
+public class CreateCommentRequestDto { // 댓글 생성 요청 DTO 선언
+    @NotBlank(message = "내용은 필수입니다.") // 공백 불가 검증
+    @Size(max = 1000, message = "내용은 최대 1000자 입니다.") // 길이 제한
+    private String content; // 댓글 내용(최상위/대댓글 공통)
 }

--- a/backend/src/main/java/com/ottproject/ottbackend/service/CommentService.java
+++ b/backend/src/main/java/com/ottproject/ottbackend/service/CommentService.java
@@ -125,6 +125,24 @@ public class CommentService {
         if (updated == 0) throw new IllegalArgumentException("comment not found: " + commentId); // 없으면 예외
     }
 
+    public Long createReply(Long userId, Long parentId, String content) { // 대댓글 생성(부모에서 리뷰 ID 유추)
+        User user = userRepository.findById(userId) // 사용자 조회(필수)
+                .orElseThrow(() -> new IllegalArgumentException("user not found: " + userId)); // 없으면 예외
+        Comment parent = commentRepository.findById(parentId) // 부모 댓글 조회(필수)
+                .orElseThrow(() -> new IllegalArgumentException("parent comment not found: " + parentId)); // 없으면 예외
+        Review review = parent.getReview(); // 부모 댓글이 속한 리뷰 엔티티 추출
+
+        Comment reply = Comment.builder() // 댓글 엔티티 빌드
+                .user(user) // 작성자 연관
+                .review(review) // 부모 댓글의 리뷰로 설정
+                .parent(parent) // 부모 댓글 연관
+                .content(content) // 내용
+                .status(CommentStatus.ACTIVE) // 기본 상태
+                .build(); // 엔티티 생성 완료
+
+        return commentRepository.save(reply).getId(); // 저장 후 생성 PK 반환
+    }
+
     public void deleteHardByReview(Long reviewId) {
         commentRepository.deleteByReviewId(reviewId); // 특정 리뷰의 댓글 하드 삭제
     }

--- a/backend/src/test/java/com/ottproject/ottbackend/controller/CommentControllerTest.java
+++ b/backend/src/test/java/com/ottproject/ottbackend/controller/CommentControllerTest.java
@@ -1,8 +1,16 @@
 package com.ottproject.ottbackend.controller;
 
-import com.ottproject.ottbackend.entity.*;
-import com.ottproject.ottbackend.enums.*;
-import com.ottproject.ottbackend.repository.*;
+import com.ottproject.ottbackend.entity.AniList;
+import com.ottproject.ottbackend.entity.Comment;
+import com.ottproject.ottbackend.entity.Review;
+import com.ottproject.ottbackend.entity.User;
+import com.ottproject.ottbackend.enums.AnimeStatus;
+import com.ottproject.ottbackend.enums.CommentStatus;
+import com.ottproject.ottbackend.enums.ReviewStatus;
+import com.ottproject.ottbackend.repository.AniListRepository;
+import com.ottproject.ottbackend.repository.CommentRepository;
+import com.ottproject.ottbackend.repository.ReviewRepository;
+import com.ottproject.ottbackend.repository.UserRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,103 +23,255 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*; // get/post/patch/delete
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*; // stat
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-@SpringBootTest // 전체 컨텍스트 로딩
-@AutoConfigureMockMvc(addFilters = false) // 보안 비활성화
-@ActiveProfiles("test") // H2 설정
-@Transactional // 롤백
-class CommentControllerTest {
+@SpringBootTest // 스프링 전체 컨텍스트 로드(컨트롤러→서비스→JPA/MyBatis→DB 왕복 흐름 검증)
+@AutoConfigureMockMvc(addFilters = false) // 인증 필터 비활성화
+@ActiveProfiles("test") // 테스트 프로파일 사용(H2)
+@Transactional // 각 테스트 케이스 종료 후 롤백
+class CommentControllerTest { // 댓글/대댓글 컨트롤러 통합 테스트 클래스
 
     @Autowired private MockMvc mockMvc; // HTTP 호출 도구
-    @Autowired private UserRepository userRepository; // 사용자 레포
-    @Autowired private AniListRepository aniListRepository; // 애니 레포
-    @Autowired private ReviewRepository reviewRepository; // 리뷰 레포
-    @Autowired private CommentRepository commentRepository; // 댓글 레포
+    @Autowired private UserRepository userRepository; // 사용자 시드/검증
+    @Autowired private AniListRepository aniListRepository; // 애니 시드
+    @Autowired private ReviewRepository reviewRepository; // 리뷰 시드/검증
+    @Autowired private CommentRepository commentRepository; // DB 상태 검증
 
-    private User seedUser(String email) { // 사용자 시드
-        return userRepository.save(User.builder().email(email).password("X").name("tester").build()); // 저장
-    }
+    private User seedUser(String email) { // 사용자 시드 생성
+        return userRepository.save( // JPA 저장
+                User.builder().email(email).password("X").name("tester").build() // 엔티티 빌드
+        ); // 저장 후 반환
+    } // seedUser 끝
 
-    private AniList seedAni() { // 애니 시드(필수 컬럼 모두 채움)
-        return aniListRepository.save(AniList.builder()
-                .title("Test Title").posterUrl("http://poster").totalEpisodes(12)
-                .status(AnimeStatus.ONGOING).releaseDate(LocalDate.now()).endDate(null)
-                .isExclusive(true).isNew(false).isPopular(false).isCompleted(false)
-                .isSubtitle(true).isDub(false).isSimulcast(false)
-                .broadcastDay("MON").broadCastTime("20:00").season("SPRING")
-                .year(2024).type("TV").duration(24).source("ORIGINAL")
-                .country("KR").language("KO").isActive(true).build());
-    }
+    private AniList seedAni() { // 애니 시드 생성
+        return aniListRepository.save( // JPA 저장
+                AniList.builder()
+                        .title("Test Title").posterUrl("http://poster").totalEpisodes(12)
+                        .status(AnimeStatus.ONGOING).releaseDate(LocalDate.now()).endDate(null)
+                        .isExclusive(true).isNew(false).isPopular(false).isCompleted(false)
+                        .isSubtitle(true).isDub(false).isSimulcast(false)
+                        .broadcastDay("MON").broadCastTime("20:00").season("SPRING")
+                        .year(2024).type("TV").duration(24).source("ORIGINAL")
+                        .country("KR").language("KO").isActive(true).build()
+        ); // 저장 후 반환
+    } // seedAni 끝
 
-    private Review seedReview(User user, AniList ani) { // 리뷰 시드
-        return reviewRepository.save(Review.builder()
-                .user(user).aniList(ani).status(ReviewStatus.ACTIVE)
-                .content("seed").rating(3.5).build());
-    }
+    private Review seedReview(User user, AniList ani) { // 리뷰 시드 생성(댓글 상위 리소스)
+        return reviewRepository.save( // JPA 저장
+                Review.builder()
+                        .user(user).aniList(ani).status(ReviewStatus.ACTIVE)
+                        .content("seed").rating(3.5).build()
+        ); // 저장 후 반환
+    } // seedReview 끝
+
+    private Long createCommentViaApi(Review review, User user, String content) throws Exception { // 최상위 댓글을 API 로 생성하는 헬퍼
+        String body = String.format("{\"content\":\"%s\"}", content);
+        String idStr = mockMvc.perform( // HTTP 실행
+                        post("/api/reviews/{reviewId}/comments", review.getId()) // 최상위 댓글 생성 엔드포인트
+                                .param("userId", String.valueOf(user.getId())) // 작성자 ID
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(body) // 내용(JSON 바디)
+                )
+                .andExpect(status().isOk()) // 200 OK + 생성 PK
+                .andReturn().getResponse().getContentAsString(); // 생성 PK 문자열 추출
+        return Long.parseLong(idStr); // Long 변환 후 반환
+        // userId, content 를 쿼리 파라미터로 전달 → 컨트롤러 호출 → 서비스 로직 실행 → 리포지토리 save(...)로 DB 저장 → 응답 본문에 생성 PK 수신
+        // 반환된 PK를 이용해 이후 조회/수정/삭제 등 검증 수행
+    } // createCommentViaApi 끝
+
+    private Long createReplyViaApi(Long parentCommentId, Long userId, String content) throws Exception { // 대댓글을 API 로 생성하는 헬퍼
+        String body = String.format("{\"content\":\"%s\"}", content);
+        String idStr = mockMvc.perform( // HTTP 실행
+                        post("/api/comments/{commentId}/replies", parentCommentId) // 대댓글 생성 엔드포인트
+                                .param("userId", String.valueOf(userId)) // 작성자 ID
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(body) // 대댓글 내용(JSON 바디)
+                )
+                .andExpect(status().isOk()) // 200 OK + 생성 PK
+                .andReturn().getResponse().getContentAsString(); // 생성 PK 추출
+        return Long.parseLong(idStr); // Long 변환
+    } // createReplyViaApi 끝
 
     @Test
-    @DisplayName("댓글 목록(MyBatis) 조회가 H2에서 동작한다")
-    void listComments_ok() throws Exception {
-        User user = seedUser("x@a.com"); // 사용자
-        AniList ani = seedAni(); // 애니
-        Review review = seedReview(user, ani); // 리뷰
-        commentRepository.save(Comment.builder() // 최상위 댓글 1건
-                .user(user).review(review).content("c1").status(CommentStatus.ACTIVE).build());
-
-        mockMvc.perform(get("/api/reviews/{reviewId}/comments", review.getId()) // GET
-                        .param("page", "0").param("size", "10")
-                        .accept(MediaType.APPLICATION_JSON))
-                        .andExpect(status().isOk()) // 200
-                        .andExpect(jsonPath("$.total").value(1)) // 총 1건
-                        .andExpect(jsonPath("$.items.length()").value(1)); // 아이템 1
-    }
+    @DisplayName("댓글 목록(MyBatis) 조회가 H2에서 동작한다") // 목록 XML 동작 검증
+    void listComments_ok() throws Exception { // 최상위 댓글 목록 테스트
+        User user = seedUser("x@a.com"); // 사용자 시드
+        AniList ani = seedAni(); // 애니 시드
+        Review review = seedReview(user, ani); // 리뷰 시드
+        createCommentViaApi(review, user, "c1"); // API로 최상위 댓글 1건 생성
+        mockMvc.perform( // 목록 조회
+                        get("/api/reviews/{reviewId}/comments", review.getId()) // 엔드포인트
+                                .param("page", "0").param("size", "10") // 페이징
+                                .accept(MediaType.APPLICATION_JSON) // JSON
+                )
+                .andExpect(status().isOk()) // 200
+                .andExpect(jsonPath("$.total").value(1)) // 총 1건
+                .andExpect(jsonPath("$.items.length()").value(1)); // 아이템 1개
+    } // listComments_ok 끝
 
     @Test
-    @DisplayName("댓글 생성(JPA) 후 목록(MyBatis)에서 조회된다 -> 상태변경(PATCH) 후 목록에서 제외된다")
-    void createThenPatchStatus_ok() throws Exception {
+    @DisplayName("댓글 생성 → 상태변경(PATCH) → 목록 제외") // 생성/상태변경/목록 제외 플로우
+    void createThenPatchStatus_ok() throws Exception { // 관리/모더레이션 엔드포인트 검증
         User user = seedUser("y@a.com"); // 사용자
         AniList ani = seedAni(); // 애니
         Review review = seedReview(user, ani); // 리뷰
-
-        mockMvc.perform(post("/api/reviews/{reviewId}/comments", review.getId()) // 생성
-                .param("userId", String.valueOf(user.getId()))
-                .param("content", "hello"))
-                .andExpect(status().isOk()); // 200
-        mockMvc.perform(get("/api/reviews/{reviewId}/comments", review.getId()) // 생성 확인
-                .param("page", "0").param("size", "10"))
+        Long commentId = createCommentViaApi(review, user, "hello"); // 최상위 댓글 생성
+        mockMvc.perform( // 목록 확인
+                        get("/api/reviews/{reviewId}/comments", review.getId())
+                                .param("page", "0").param("size", "10")
+                )
                 .andExpect(status().isOk()) // 200
                 .andExpect(jsonPath("$.total").value(1)); // 1건
-
-        Long commentId = commentRepository.findAll().get(0).getId(); // 방금 생성된 댓글 ID
-
-        mockMvc.perform(patch("/api/reviews/{reviewId}/comments/{commentId}/status",
-                review.getId(), commentId) // 상태변경
-                .param("status", CommentStatus.DELETED.name()))
+        mockMvc.perform( // 상태변경: DELETED 전환
+                        patch("/api/reviews/{reviewId}/comments/{commentId}/status", review.getId(), commentId)
+                                .param("status", CommentStatus.DELETED.name())
+                )
                 .andExpect(status().isNoContent()); // 204
-
-        mockMvc.perform(get("/api/reviews/{reviewId}/comments", review.getId()) // 목록 확인
-                .param("page", "0").param("size", "10"))
+        mockMvc.perform( // 목록 재호출
+                        get("/api/reviews/{reviewId}/comments", review.getId())
+                                .param("page", "0").param("size", "10")
+                )
                 .andExpect(status().isOk()) // 200
-                .andExpect(jsonPath("$.total").value(0)); // ACTIVE 필터에 걸려 0건
-    }
-    
+                .andExpect(jsonPath("$.total").value(0)); // ACTIVE 필터로 0건
+    } // createThenPatchStatus_ok 끝
+
     @Test
-    @DisplayName("리뷰의 모든 댓글 일괄 삭제 후 목록이 비어있다")
-    void deleteAllByReview_ok() throws Exception {
-        User user = seedUser("z@a.com");
-        AniList ani = seedAni();
-        Review review = seedReview(user, ani);
-        commentRepository.save(Comment.builder()
-                .user(user).review(review).content("seed").status(CommentStatus.ACTIVE).build());
-        
-        mockMvc.perform(delete("/api/reviews/{reviewId}/comments", review.getId())) // 일괄 삭제
+    @DisplayName("리뷰의 모든 댓글 일괄 삭제 후 목록이 비어있다") // DELETE /api/reviews/{reviewId}/comments
+    void deleteAllByReview_ok() throws Exception { // 일괄 삭제
+        User user = seedUser("z@a.com"); // 사용자
+        AniList ani = seedAni(); // 애니
+        Review review = seedReview(user, ani); // 리뷰
+        createCommentViaApi(review, user, "seed"); // 댓글 생성
+        mockMvc.perform( // 일괄 삭제 호출
+                        delete("/api/reviews/{reviewId}/comments", review.getId())
+                )
                 .andExpect(status().isNoContent()); // 204
-        
-        mockMvc.perform(get("/api/reviews/{reviewId}/comments", review.getId()) // 목록 확인
-                .param("page", "0").param("size", "10"))
+        mockMvc.perform( // 목록 확인
+                        get("/api/reviews/{reviewId}/comments", review.getId())
+                                .param("page", "0").param("size", "10")
+                )
                 .andExpect(status().isOk()) // 200
                 .andExpect(jsonPath("$.total").value(0)); // 0건
-    }
-}
+    } // deleteAllByReview_ok 끝
+
+    @Test
+    @DisplayName("댓글 수정(본인) → 204, 목록에 변경 내용 반영") // PUT /api/comments/{id}
+    void updateComment_ok() throws Exception { // 본인 수정 플로우
+        User user = seedUser("c-upd@a.com"); // 사용자
+        AniList ani = seedAni(); // 애니
+        Review review = seedReview(user, ani); // 리뷰
+        Long commentId = createCommentViaApi(review, user, "orig"); // 댓글 생성
+        String body = "{\"content\":\"edited\"}"; // 수정 바디
+        mockMvc.perform( // 수정 호출
+                        put("/api/comments/{id}", commentId)
+                                .param("userId", String.valueOf(user.getId()))
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(body)
+                )
+                .andExpect(status().isNoContent()); // 204
+        Comment updated = commentRepository.findById(commentId).orElseThrow(); // DB에서 내용 확인
+        assertEquals("edited", updated.getContent()); // 내용 검증
+    } // updateComment_ok 끝
+
+    @Test
+    @DisplayName("댓글 삭제(본인) → 목록에서 제외") // DELETE /api/comments/{id}
+    void deleteComment_soft_ok() throws Exception { // 소프트 삭제
+        User user = seedUser("c-del@a.com"); // 사용자
+        AniList ani = seedAni(); // 애니
+        Review review = seedReview(user, ani); // 리뷰
+        Long commentId = createCommentViaApi(review, user, "seed"); // 댓글 생성
+        mockMvc.perform( // 삭제 호출
+                        delete("/api/comments/{id}", commentId)
+                                .param("userId", String.valueOf(user.getId()))
+                )
+                .andExpect(status().isNoContent()); // 204
+        mockMvc.perform( // 목록 확인
+                        get("/api/reviews/{reviewId}/comments", review.getId())
+                                .param("page","0").param("size","10")
+                )
+                .andExpect(status().isOk()) // 200
+                .andExpect(jsonPath("$.total").value(0)); // 제외됨
+    } // deleteComment_soft_ok 끝
+
+    @Test
+    @DisplayName("댓글 신고 → 목록에서 제외") // POST /api/comments/{id}/report
+    void reportComment_ok() throws Exception { // 신고 플로우
+        User user = seedUser("c-rep@a.com"); // 사용자
+        AniList ani = seedAni(); // 애니
+        Review review = seedReview(user, ani); // 리뷰
+        Long commentId = createCommentViaApi(review, user, "seed"); // 댓글 생성
+        mockMvc.perform( // 신고 호출
+                        post("/api/comments/{id}/report", commentId)
+                                .param("userId", String.valueOf(user.getId()))
+                )
+                .andExpect(status().isNoContent()); // 204
+        mockMvc.perform( // 목록 확인
+                        get("/api/reviews/{reviewId}/comments", review.getId())
+                                .param("page","0").param("size","10")
+                )
+                .andExpect(status().isOk()) // 200
+                .andExpect(jsonPath("$.total").value(0)); // 신고된 댓글 제외
+    } // reportComment_ok 끝
+
+    @Test
+    @DisplayName("댓글 좋아요 토글 → true → false") // POST /api/comments/{id}/like
+    void toggleCommentLike_ok() throws Exception { // 좋아요 토글
+        User user = seedUser("c-like@a.com"); // 사용자
+        AniList ani = seedAni(); // 애니
+        Review review = seedReview(user, ani); // 리뷰
+        Long commentId = createCommentViaApi(review, user, "seed"); // 댓글 생성
+        mockMvc.perform( // 첫 토글(on)
+                        post("/api/comments/{id}/like", commentId)
+                                .param("userId", String.valueOf(user.getId()))
+                                .accept(MediaType.APPLICATION_JSON)
+                )
+                .andExpect(status().isOk()) // 200
+                .andExpect(content().string("true")); // on
+        mockMvc.perform( // 두번째 토글(off)
+                        post("/api/comments/{id}/like", commentId)
+                                .param("userId", String.valueOf(user.getId()))
+                                .accept(MediaType.APPLICATION_JSON)
+                )
+                .andExpect(status().isOk()) // 200
+                .andExpect(content().string("false")); // off
+    } // toggleCommentLike_ok 끝
+
+    @Test
+    @DisplayName("대댓글 생성 → 대댓글 목록에서 조회된다") // POST/GET /api/comments/{commentId}/replies
+    void replies_create_and_list_ok() throws Exception { // 대댓글 플로우
+        User user = seedUser("c-reply@a.com"); // 사용자
+        AniList ani = seedAni(); // 애니
+        Review review = seedReview(user, ani); // 리뷰
+        Long parentId = createCommentViaApi(review, user, "parent"); // 부모 댓글 생성
+        Long replyId = createReplyViaApi(parentId, user.getId(), "child"); // 대댓글 생성
+        mockMvc.perform( // 대댓글 목록 호출
+                        get("/api/comments/{commentId}/replies", parentId)
+                                .param("currentUserId", String.valueOf(user.getId()))
+                )
+                .andExpect(status().isOk()) // 200
+                .andExpect(jsonPath("$.length()").value(1)) // 한 건
+                .andExpect(jsonPath("$[0].id").value(replyId)) // 방금 생성된 대댓글
+                .andExpect(jsonPath("$[0].parentId").value(parentId)); // 부모 ID 일치
+    } // replies_create_and_list_ok 끝
+
+    @Test
+    @DisplayName("댓글 정렬 best → 좋아요 많은 댓글이 먼저 온다") // sort=best 분기 검증
+    void comment_sort_best_ok() throws Exception { // MyBatis 정렬 분기 테스트
+        User u1 = seedUser("s1@a.com"); // 사용자1
+        User u2 = seedUser("s2@a.com"); // 사용자2
+        AniList ani = seedAni(); // 애니
+        Review review = seedReview(u1, ani); // 리뷰
+        Long c1 = createCommentViaApi(review, u1, "a"); // 댓글1
+        Long c2 = createCommentViaApi(review, u1, "b"); // 댓글2
+        mockMvc.perform(post("/api/comments/{id}/like", c2).param("userId", String.valueOf(u1.getId()))); // c2 like by u1
+        mockMvc.perform(post("/api/comments/{id}/like", c2).param("userId", String.valueOf(u2.getId()))); // c2 like by u2
+        mockMvc.perform( // best 정렬 목록 호출
+                        get("/api/reviews/{reviewId}/comments", review.getId())
+                                .param("page","0").param("size","10").param("sort","best")
+                )
+                .andExpect(status().isOk()) // 200
+                .andExpect(jsonPath("$.items[0].id").value(c2)); // 좋아요 더 많은 c2가 첫 번째
+    } // comment_sort_best_ok 끝
+} // CommentControllerTest 끝

--- a/backend/src/test/java/com/ottproject/ottbackend/controller/ReviewControllerTest.java
+++ b/backend/src/test/java/com/ottproject/ottbackend/controller/ReviewControllerTest.java
@@ -1,145 +1,193 @@
 package com.ottproject.ottbackend.controller;
 
-import com.ottproject.ottbackend.entity.*;
-import com.ottproject.ottbackend.enums.*;
-import com.ottproject.ottbackend.repository.*;
+import com.ottproject.ottbackend.entity.AniList;
+import com.ottproject.ottbackend.entity.Review;
+import com.ottproject.ottbackend.entity.User;
+import com.ottproject.ottbackend.enums.AnimeStatus;
+import com.ottproject.ottbackend.enums.ReviewStatus;
+import com.ottproject.ottbackend.repository.AniListRepository;
+import com.ottproject.ottbackend.repository.ReviewRepository;
+import com.ottproject.ottbackend.repository.UserRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.http.MediaType; // 미디어 타입
+import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDate; // 날짜 타입
+import java.time.LocalDate;
 
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*; // get/post/delete 등
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*; // status/json 검증
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-@SpringBootTest // 스프링 부트 전체 컨텍스트 로딩(서비스/레포/매퍼/XML 포함)
-@AutoConfigureMockMvc(addFilters = false) // 보안 필터 비활성화(인증 없이 테스트)
-@ActiveProfiles("test") // application-test.yml(H2) 적용
-@Transactional // 각 테스트 후 롤백    
-class ReviewControllerTest { // 리뷰 통합 테스트 클래스
+@SpringBootTest // 스프링 전체 컨텍스트 로드(컨트롤러→서비스→JPA/MyBatis→DB 왕복 흐름 검증)
+@AutoConfigureMockMvc(addFilters = false) // 인증 필터 비활성화(HTTP 레이어를 단순화)
+@ActiveProfiles("test") // 테스트 프로파일(H2) 사용
+@Transactional // 각 테스트 종료 시 롤백 보장(테스트 간 데이터 격리)
+class ReviewControllerTest { // 리뷰 컨트롤러 통합 테스트 클래스 시작
 
-    @Autowired private MockMvc mockMvc; // HTTP 요청/응답 테스트용
-    @Autowired private UserRepository userRepository; // 사용자 레포(시드/검증)
-    @Autowired private AniListRepository aniListRepository; // 애니 레포(시드)
-    @Autowired private ReviewRepository reviewRepository; // 리뷰 레포(검증)
-    
-    private User seedUser(String email) { // 사용자 시드 헬퍼
-        User u = User.builder() // 빌더로 생성
-                .email(email) // 이메일
-                .password("X") // 임시 값
-                .name("tester") // 이름
-                .build(); // 나머지 빌드는 @Builder.Default
-        return userRepository.save(u); // 저장 후 반환
-    }
+    @Autowired private MockMvc mockMvc; // HTTP 요청/응답 모킹 도구 주입
+    @Autowired private UserRepository userRepository; // 사용자 JPA 레포지토리(시드/검증)
+    @Autowired private AniListRepository aniListRepository; // 애니 JPA 레포지토리(시드)
+    @Autowired private ReviewRepository reviewRepository; // 리뷰 JPA 레포지토리(DB 상태 검증)
 
-    private AniList sendAni() { // 애니 시드 헬퍼(필수 컬럼 모두 채움)
-        AniList a = AniList.builder()
-                .title("Test Title")
-                .posterUrl("http://poster")
-                .totalEpisodes(12)
-                .status(AnimeStatus.ONGOING)
-                .releaseDate(LocalDate.now())
-                .endDate(null)
-                .ageRating("ALL")
-                .rating(4.2)
-                .ratingCount(10)
-                .isExclusive(true)
-                .isNew(false)
-                .isPopular(false)
-                .isCompleted(false)
-                .isSubtitle(true)
-                .isDub(false)
-                .isSimulcast(false)
-                .broadcastDay("MON")
-                .broadCastTime("20:00")
-                .season("SPRING")
-                .year(2024)
-                .type("TV")
-                .duration(24)
-                .source("ORIGINAL")
-                .country("KR")
-                .language("KO")
-                .isActive(true)
-                .build();
-        return aniListRepository.save(a); // 저장
-    }
+    private User seedUser(String email) { // 사용자 시드 생성 헬퍼
+        return userRepository.save( // JPA 저장 호출
+                User.builder() // 빌더 시작
+                        .email(email) // 이메일 세팅
+                        .password("X") // 패스워드(테스트용)
+                        .name("tester") // 이름
+                        .build() // 엔티티 빌드
+        ); // 저장 후 영속 엔티티 반환
+    } // seedUser 끝
 
-    @Test
-    @DisplayName("리뷰 목록(MyBatis) 조회가 실제 DB(H2)에서 동작한다")
-    void listReviews_fromMyBatis_ok() throws Exception {
-        User user = seedUser("a@a.com"); // 사용자 시드
-        AniList ani = sendAni(); // 애니 시드
+    private AniList seedAni() { // 애니 시드 생성 헬퍼
+        return aniListRepository.save( // JPA 저장
+                AniList.builder() // 빌더 시작
+                        .title("Test Title") // 제목
+                        .posterUrl("http://poster") // 포스터 URL
+                        .totalEpisodes(12) // 총 화수
+                        .status(AnimeStatus.ONGOING) // 방영 상태
+                        .releaseDate(LocalDate.now()) // 시작일
+                        .endDate(null) // 종료일 없음
+                        .ageRating("ALL") // 연령 등급
+                        .rating(4.2) // 초기 평점
+                        .ratingCount(10) // 평점 수
+                        .isExclusive(true) // 독점 여부
+                        .isNew(false) // 신작 여부
+                        .isPopular(false) // 인기 여부
+                        .isCompleted(false) // 완결 여부
+                        .isSubtitle(true) // 자막 여부
+                        .isDub(false) // 더빙 여부
+                        .isSimulcast(false) // 동시방영 여부
+                        .broadcastDay("MON") // 방영 요일
+                        .broadCastTime("20:00") // 방영 시각
+                        .season("SPRING") // 시즌
+                        .year(2024) // 연도
+                        .type("TV") // 타입
+                        .duration(24) // 회당 길이(분)
+                        .source("ORIGINAL") // 원작 타입
+                        .country("KR") // 국가
+                        .language("KO") // 언어
+                        .isActive(true) // 활성 여부
+                        .build() // 엔티티 빌드
+        ); // 저장 후 반환
+    } // seedAni 끝
 
-        Review review = Review.builder() // 리뷰 엔티티 생성
-                .user(user) // 연관: 작성자
-                .aniList(ani) // 연관: 애니
-                .content("good") // 내용
-                .rating(4.5) // 평점
-                .status(ReviewStatus.ACTIVE) // 상태
-                .build();
-        review = reviewRepository.save(review); // 저장
-
-        Long currentUserId = user.getId(); // 좋아요 여부 계산 파라미터
-        mockMvc.perform( // GET 호출
-                get("/api/anime/{aniId}/reviews", ani.getId()) // 경로변수 바인딩
-                        .param("currentUserId", String.valueOf(currentUserId)) // 쿼리
-                        .param("sort", "latest") // 정렬
-                        .param("page", "0") // 페이지
-                        .param("size", "10") // 크기
-                        .accept(MediaType.APPLICATION_JSON) // JSON 기대
-        )
-                .andExpect(status().isOk()) // 200
-                .andExpect(jsonPath("$.total").value(1)) // 총 개수 = 1
-                .andExpect(jsonPath("$.items[0].id").value(review.getId())) // 첫 아이템 ID = 저장한 리뷰
-                .andExpect(jsonPath("$.items[0].aniId").value(ani.getId())); // aniID 일치
-    }
-
-
-    @Test
-    @DisplayName("리뷰 생성(JPA) 후 목록(MyBatis)에서 조회된다")
-    void createReview_thenList_ok() throws Exception {
-        User user = seedUser("b@a.com"); // 사용자 시드
-        AniList ani = sendAni(); // 애니 시드
-
-        mockMvc.perform( // POST 호출
-                        post("/api/anime/{aniId}/reviews", ani.getId()) // 경로 애니 ID
-                                .param("userId", String.valueOf(user.getId())) // 작성자
-                                .param("content", "hello") // 내용
-                                .param("rating", "4.0") // 평점
+    private Long createReviewViaApi(AniList ani, User user, String content, double rating) throws Exception { // 리뷰를 API 로 생성하는 헬퍼(컨트롤러부터 시작 보장)
+        String body = String.format("{\"aniId\":%d,\"content\":\"%s\",\"rating\":%.1f}", ani.getId(), content, rating); // CreateReviewRequestDto 요구사항에 맞춰 aniId/내용/평점 JSON 구성
+        String idStr = mockMvc.perform( // HTTP 요청 실행
+                        post("/api/anime/{aniId}/reviews", ani.getId()) // 엔드포인트(경로변수 aniId 포함)
+                                .param("userId", String.valueOf(user.getId())) // 작성자 ID는 쿼리 파라미터로
+                                .contentType(MediaType.APPLICATION_JSON) // JSON 타입 지정
+                                .content(body) // 바디로 DTO 전달
                 )
-                .andExpect(status().isOk()); // 200(생성 ID 본문)
-
-        mockMvc.perform( // 생성 후 목록 확인
-                        get("/api/anime/{aniId}/reviews", ani.getId())
-                                .param("page", "0")
-                                .param("size", "10")
-                )
-                .andExpect(status().isOk()) // 200
-                .andExpect(jsonPath("$.total").value(1)); // 총 1건
-    }
+                .andExpect(status().isOk()) // 생성 성공(본문에 생성 PK 반환)
+                .andReturn().getResponse().getContentAsString(); // 본문에서 생성된 PK 스트링 추출
+        return Long.parseLong(idStr); // Long 변환 후 반환
+        // JSON 바디 전달 → 컨트롤러 호출 → 서비스 로직 실행 → DB 저장 후 생성 PK 응답 수신
+        // 반환된 PK로 이후 검증(조회, 수정, 삭제 등) 수행
+    } // createReviewViaApi 끝
 
     @Test
-    @DisplayName("특정 애니의 리뷰 일괄 삭제(DML) 후 목록이 비어있다")
-    void deleteAllReviewsByAni_ok() throws Exception {
-        User user = seedUser("c@a.com"); // 사용자
-        AniList ani = sendAni(); // 애니
-        Review review = Review.builder() // 리뷰 1건 저장
-                .user(user).aniList(ani).status(ReviewStatus.ACTIVE)
-                .content("X").rating(3.0).build();
-        reviewRepository.save(review); // 저장
+    @DisplayName("리뷰 목록은 API 생성 후 MyBatis 로 조회된다") // CUD=JPA(API 경유), R=MyBatis(목록 XML) 검증
+    void listReviews_viaApiSeed_ok() throws Exception { // 목록 테스트
+        User user = seedUser("list@a.com"); // 사용자 시드
+        AniList ani = seedAni(); // 애니 시드
+        Long reviewId = createReviewViaApi(ani, user, "good", 4.5); // 컨트롤러부터 시작해 리뷰 생성
+        mockMvc.perform( // 목록 조회(읽기는 MyBatis XML)
+                        get("/api/anime/{aniId}/reviews", ani.getId()) // 애니 하위 리뷰 목록
+                                .param("currentUserId", String.valueOf(user.getId())) // 좋아요 여부 계산용
+                                .param("sort", "latest") // 최신순 정렬
+                                .param("page", "0") // 0페이지
+                                .param("size", "10") // 페이지 크기 10
+                                .accept(MediaType.APPLICATION_JSON) // JSON 응답 기대
+                )
+                .andExpect(status().isOk()) // 200 OK
+                .andExpect(jsonPath("$.total").value(1)) // 총 1건
+                .andExpect(jsonPath("$.items[0].id").value(reviewId)); // 첫 아이템이 방금 생성된 리뷰
+    } // listReviews_viaApiSeed_ok 끝
 
-        mockMvc.perform(delete("/api/anime/{aniId}/reviews", ani.getId())) // 삭제
+    @Test
+    @DisplayName("리뷰 수정(본인) → 204, DB 반영 확인") // PUT /api/reviews/{id}
+    void updateReview_allViaApi_ok() throws Exception { // 수정 플로우
+        User user = seedUser("upd@a.com"); // 사용자 시드
+        AniList ani = seedAni(); // 애니 시드
+        Long reviewId = createReviewViaApi(ani, user, "orig", 3.0); // API 로 리뷰 생성
+        String body = "{\"content\":\"edited\",\"rating\":4.0}"; // 수정 JSON 바디
+        mockMvc.perform( // 수정 호출
+                        put("/api/reviews/{id}", reviewId) // 리뷰 단건 수정 엔드포인트
+                                .param("userId", String.valueOf(user.getId())) // 본인 검증(임시)
+                                .contentType(MediaType.APPLICATION_JSON) // JSON
+                                .content(body) // 수정 바디
+                )
+                .andExpect(status().isNoContent()); // 204 성공(본문 없음)
+        Review updated = reviewRepository.findById(reviewId).orElseThrow(); // DB 에서 실제 값 확인(JPA 단순 조회)
+        assertEquals("edited", updated.getContent()); // 내용 갱신 검증
+        assertEquals(4.0, updated.getRating()); // 평점 갱신 검증
+    } // updateReview_allViaApi_ok 끝
+
+    @Test
+    @DisplayName("리뷰 삭제(본인) → 목록에서 제외") // DELETE /api/reviews/{id}
+    void deleteReview_soft_ok() throws Exception { // 소프트 삭제 플로우
+        User user = seedUser("del@a.com"); // 사용자
+        AniList ani = seedAni(); // 애니
+        Long reviewId = createReviewViaApi(ani, user, "c", 3.0); // API 생성
+        mockMvc.perform( // 삭제 호출
+                        delete("/api/reviews/{id}", reviewId) // 단건 삭제(소프트)
+                                .param("userId", String.valueOf(user.getId())) // 본인 확인
+                )
                 .andExpect(status().isNoContent()); // 204
-
-        mockMvc.perform(get("/api/anime/{aniId}/reviews", ani.getId()) // 목록 확인
-                .param("page", "0").param("size", "10"))
+        mockMvc.perform( // 목록 재호출
+                        get("/api/anime/{aniId}/reviews", ani.getId())
+                                .param("page", "0").param("size", "10")
+                )
                 .andExpect(status().isOk()) // 200
-                .andExpect(jsonPath("$.total").value(0)); // 0건
-    }
-}
+                .andExpect(jsonPath("$.total").value(0)); // ACTIVE 필터로 제외됨
+    } // deleteReview_soft_ok 끝
+
+    @Test
+    @DisplayName("리뷰 신고 → 목록에서 제외") // POST /api/reviews/{id}/report
+    void reportReview_ok() throws Exception { // 신고 플로우
+        User user = seedUser("rep@a.com"); // 사용자
+        AniList ani = seedAni(); // 애니
+        Long reviewId = createReviewViaApi(ani, user, "c", 3.0); // 생성
+        mockMvc.perform( // 신고 호출
+                        post("/api/reviews/{id}/report", reviewId) // 신고 엔드포인트
+                                .param("userId", String.valueOf(user.getId())) // 신고자 ID
+                )
+                .andExpect(status().isNoContent()); // 204
+        mockMvc.perform( // 목록 재호출
+                        get("/api/anime/{aniId}/reviews", ani.getId())
+                                .param("page", "0").param("size", "10")
+                )
+                .andExpect(status().isOk()) // 200
+                .andExpect(jsonPath("$.total").value(0)); // REPORTED 는 목록에서 제외
+    } // reportReview_ok 끝
+
+    @Test
+    @DisplayName("리뷰 좋아요 토글 → true → false") // POST /api/reviews/{id}/like
+    void toggleReviewLike_ok() throws Exception { // 좋아요 on/off 플로우
+        User user = seedUser("like@a.com"); // 사용자
+        AniList ani = seedAni(); // 애니
+        Long reviewId = createReviewViaApi(ani, user, "c", 3.0); // 생성
+        mockMvc.perform( // 첫 토글(on)
+                        post("/api/reviews/{id}/like", reviewId)
+                                .param("userId", String.valueOf(user.getId()))
+                                .accept(MediaType.APPLICATION_JSON)
+                )
+                .andExpect(status().isOk()) // 200
+                .andExpect(content().string("true")); // true(on)
+        mockMvc.perform( // 두번째 토글(off)
+                        post("/api/reviews/{id}/like", reviewId)
+                                .param("userId", String.valueOf(user.getId()))
+                                .accept(MediaType.APPLICATION_JSON)
+                )
+                .andExpect(status().isOk()) // 200
+                .andExpect(content().string("false")); // false(off)
+    } // toggleReviewLike_ok 끝
+} // ReviewControllerTest 끝


### PR DESCRIPTION
featE: Added endpoints for review/comment editing, soft deletion, reporting, liking, reply list, and reply creation.
Changed the logic using parameters to receive content as a JSON DTO (CreateCommentRequestDto). Replies were inferred from the service using only the parentId path variable.
fiX: Before modification: reviewId, parentId, and content fields. After modification: only a single content field (simplified JSON body).
fiX: Before modification: create(userId, reviewId, parentId, content) relied on parameters for review/parent. After modification: add createReply(userId, parentId, content) to infer review IDs by querying parent comments.
test: Integrated verification of the actual DB round-trip flow: controller → service → JPA (CUD) save/edit/delete → MyBatis (XML) query (R).