### PR TITLE
Feat/ott player logic

### DIFF
--- a/backend/src/main/java/com/ottproject/ottbackend/config/MvcConfig.java
+++ b/backend/src/main/java/com/ottproject/ottbackend/config/MvcConfig.java
@@ -1,0 +1,23 @@
+package com.ottproject.ottbackend.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+/**
+ * Web MVC 설정
+ * - CORS 설정(로컬 Next.js와 연동)
+ */
+@Configuration
+public class MvcConfig implements WebMvcConfigurer {
+	@Override
+	public void addCorsMappings(CorsRegistry registry) { // CORS 매핑 추가
+		registry.addMapping("/api/**") // API 경로 허용
+				.allowCredentials(true) // 쿠키 전송 허용
+				.allowedMethods("GET","POST","PUT","DELETE","OPTIONS") // 메서드 허용
+				.allowedHeaders("*") // 헤더 허용
+				.allowedOrigins("http://localhost:3000"); // 프론트 오리진
+	}
+}
+
+

--- a/backend/src/main/java/com/ottproject/ottbackend/config/WebSecurityConfig.java
+++ b/backend/src/main/java/com/ottproject/ottbackend/config/WebSecurityConfig.java
@@ -59,6 +59,9 @@ public class WebSecurityConfig {
                         .requestMatchers("/api/oauth2/**").permitAll() // OAuth2 API 엔드포인트 허용
                         .requestMatchers("/oauth2/success").permitAll() // OAuth2 성공 페이지 허용
                         .requestMatchers("/oauth2/failure").permitAll() // OAuth2 실패 페이지 허용
+                        .requestMatchers("/api/episodes/*/skips").permitAll() // 스킵 메타 조회 공개
+                        .requestMatchers("/api/episodes/*/skips/track").permitAll() // 스킵 사용 로깅 공개
+                        .requestMatchers("/v3/api-docs/**", "/swagger-ui.html", "/swagger-ui/**").permitAll() // OpenAPI
                         .requestMatchers("/").permitAll() // 루트 경로 허용 (헬스체크용)
                         .requestMatchers("/health").permitAll() // 헬스체크 경로 허용
                         .anyRequest().authenticated() // 그 외 모든 요청은 인증 필요

--- a/backend/src/main/java/com/ottproject/ottbackend/controller/PlayerController.java
+++ b/backend/src/main/java/com/ottproject/ottbackend/controller/PlayerController.java
@@ -1,0 +1,84 @@
+package com.ottproject.ottbackend.controller;
+
+import com.ottproject.ottbackend.dto.EpisodeProgressRequestDto;
+import com.ottproject.ottbackend.dto.BulkProgressRequestDto;
+import com.ottproject.ottbackend.dto.StreamUrlResponseDto;
+import com.ottproject.ottbackend.service.PlayerAuthService;
+import com.ottproject.ottbackend.service.ProgressService;
+import com.ottproject.ottbackend.util.AuthUtil;
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.validation.annotation.Validated;
+import jakarta.validation.Valid;
+
+/**
+ * 플레이어 관련 API 컨트롤러
+ * - 스트림 URL 발급(secure_link 서명)
+ * - 시청 진행률 저장/조회(단건/벌크)
+ * - 다음 화 조회(자동재생)
+ */
+@RestController // REST 컨트롤러 등록
+@RequiredArgsConstructor // 생성자 주입 자동 생성
+@Validated // 요청 검증 활성화
+public class PlayerController { // 스트리밍/진행률
+    private final PlayerAuthService auth; private final ProgressService progress; private final AuthUtil authUtil; // 의존성 주입
+
+    /**
+     * 에피소드 재생용 서명된 스트림 URL 발급
+     * - 세션에서 사용자 식별, 권한 검사 실패 시 403
+     * - 성공 시 secure_link 파라미터가 포함된 m3u8 URL 반환
+     */
+    @GetMapping("/api/episodes/{id}/stream-url") // 서명 URL 발급 엔드포인트
+    public ResponseEntity<StreamUrlResponseDto> streamUrl(@PathVariable Long id, HttpSession session) { // 경로 변수/세션 입력
+        Long userId = authUtil.requireCurrentUserId(session); // 세션에서 사용자 ID 획득(미로그인 시 401)
+        if (!auth.canStream(userId, id)) return ResponseEntity.status(403).build(); // 재생 권한 없으면 403
+        String url = auth.buildSignedStreamUrl(userId, id); // secure_link 서명 URL 생성
+        return ResponseEntity.ok(StreamUrlResponseDto.builder().url(url).build()); // 바디에 URL 담아 200 OK
+    }
+
+    /**
+     * 시청 진행률 저장(멱등 upsert)
+     */
+    @PostMapping("/api/episodes/{id}/progress") // 진행률 저장 엔드포인트
+    public ResponseEntity<Void> saveProgress(@PathVariable Long id, @Valid @RequestBody EpisodeProgressRequestDto body, HttpSession session) { // 검증 적용
+        Long userId = authUtil.requireCurrentUserId(session); // 세션 사용자 확인
+        progress.upsert(userId, id, body.getPositionSec(), body.getDurationSec()); // 진행 위치/총 길이 저장(업서트)
+        return ResponseEntity.ok().build(); // 본문 없는 200 OK
+    }
+
+    /**
+     * 단건 진행률 조회(상세/카드 노출용)
+     */
+    @GetMapping("/api/episodes/{id}/progress") // 진행률 단건 조회
+    public ResponseEntity<?> getProgress(@PathVariable Long id, HttpSession session) { // 에피소드 ID 입력
+        Long userId = authUtil.requireCurrentUserId(session); // 사용자 확인
+        return ResponseEntity.ok(progress.find(userId, id).orElse(null)); // 없으면 null 반환
+    }
+
+    /**
+     * 진행률 벌크 조회(목록/카드용)
+     * - 존재하는 진행률만 맵에 포함
+     */
+    @PostMapping("/api/episodes/progress") // 벌크 조회 엔드포인트
+    public ResponseEntity<java.util.Map<Long, Object>> getProgressBulk(@Valid @RequestBody BulkProgressRequestDto body, HttpSession session) { // ID 목록 입력
+        Long userId = authUtil.requireCurrentUserId(session); // 사용자 확인
+        var result = progress.findBulk(userId, body.getEpisodeIds()); // 벌크 조회 수행
+        return ResponseEntity.ok(new java.util.HashMap<>(result)); // 결과 맵 반환
+    }
+
+    /**
+     * 다음 화 ID 조회(자동재생용)
+     */
+    @GetMapping("/api/episodes/{id}/next") // 다음 화 조회
+    public ResponseEntity<Long> nextEpisode(@PathVariable Long id) { // 현재 화 ID 입력
+        Long nextId = auth.nextEpisodeId(id); // 다음 화 탐색
+        return (nextId != null) ? ResponseEntity.ok(nextId) : ResponseEntity.noContent().build(); // 없으면 204
+    }
+}

--- a/backend/src/main/java/com/ottproject/ottbackend/controller/SettingsController.java
+++ b/backend/src/main/java/com/ottproject/ottbackend/controller/SettingsController.java
@@ -1,0 +1,40 @@
+package com.ottproject.ottbackend.controller;
+
+import com.ottproject.ottbackend.dto.UserSettingsDto;
+import com.ottproject.ottbackend.service.SettingsService;
+import com.ottproject.ottbackend.util.AuthUtil;
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 사용자 재생 환경 설정 API
+ * - 현재 사용자 설정 조회/갱신
+ */
+@RestController // REST 컨트롤러
+@RequiredArgsConstructor // 생성자 주입
+public class SettingsController { // 사용자 재생 설정
+	private final SettingsService service; private final AuthUtil authUtil; // 의존성
+
+	/**
+	 * 현재 사용자 재생 설정 조회
+	 */
+	@GetMapping("/api/users/me/settings")
+	public ResponseEntity<UserSettingsDto> get(HttpSession session) { // 세션 입력
+		Long userId = authUtil.requireCurrentUserId(session); // 사용자 확인(401 가능)
+		return ResponseEntity.ok(service.get(userId)); // 설정 반환
+	}
+	/**
+	 * 현재 사용자 재생 설정 갱신
+	 */
+	@PutMapping("/api/users/me/settings")
+	public ResponseEntity<Void> put(@RequestBody UserSettingsDto dto, HttpSession session) { // 바디 입력
+		Long userId = authUtil.requireCurrentUserId(session); // 사용자 확인
+		service.update(userId, dto); // 부분 갱신 처리
+		return ResponseEntity.noContent().build(); // 204 No Content
+	}
+}

--- a/backend/src/main/java/com/ottproject/ottbackend/controller/SkipController.java
+++ b/backend/src/main/java/com/ottproject/ottbackend/controller/SkipController.java
@@ -1,0 +1,44 @@
+package com.ottproject.ottbackend.controller;
+
+import com.ottproject.ottbackend.dto.SkipMetaResponseDto;
+import com.ottproject.ottbackend.dto.SkipUsageRequestDto;
+import com.ottproject.ottbackend.service.SkipService;
+import com.ottproject.ottbackend.util.AuthUtil;
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+import jakarta.validation.Valid;
+
+/**
+ * 스킵 메타 조회 및 사용 로깅 API
+ * - 메타는 공개 조회
+ * - 사용 로깅은 비로그인 허용(사용자 있으면 식별 포함)
+ */
+@RestController // REST 컨트롤러
+@RequiredArgsConstructor // 생성자 주입
+public class SkipController { // 스킵 메타
+	private final SkipService service; private final AuthUtil authUtil; // 의존성
+
+	/**
+	 * 에피소드 스킵 메타 조회
+	 */
+	@GetMapping("/api/episodes/{id}/skips")
+	public ResponseEntity<SkipMetaResponseDto> get(@PathVariable Long id) { // 에피소드 ID 입력
+		return ResponseEntity.ok(service.get(id)); // 메타 반환
+	}
+
+	/**
+	 * 스킵 사용/자동스킵 로깅(비로그인 허용)
+	 */
+	@PostMapping("/api/episodes/{id}/skips/track") // 스킵 사용 수집
+	public ResponseEntity<Void> track(@PathVariable Long id, @Valid @RequestBody SkipUsageRequestDto body, HttpSession session) { // 요청 바디 검증
+		Long userId = authUtil.getCurrentUserIdOrNull(session); // 로그인 시 사용자 ID, 아니면 null
+		service.trackUsage(userId, id, body.getType(), body.getAtSec()); // DB 적재
+		return ResponseEntity.accepted().build(); // 202 Accepted
+	}
+}

--- a/backend/src/main/java/com/ottproject/ottbackend/dto/BulkProgressRequestDto.java
+++ b/backend/src/main/java/com/ottproject/ottbackend/dto/BulkProgressRequestDto.java
@@ -1,0 +1,24 @@
+package com.ottproject.ottbackend.dto;
+
+import jakarta.validation.constraints.NotEmpty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+/**
+ * 진행률 벌크 조회 요청 DTO
+ * - 에피소드 ID 목록을 전달
+ */
+@Getter // 접근자 생성
+@Setter // 설정자 생성
+@NoArgsConstructor // 기본 생성자
+@AllArgsConstructor // 모든 필드 생성자
+public class BulkProgressRequestDto { // 진행률 벌크 조회 요청
+    @NotEmpty // 비어 있으면 안 됨
+    private List<Long> episodeIds; // 조회할 에피소드 ID 목록
+}
+
+

--- a/backend/src/main/java/com/ottproject/ottbackend/dto/EpisodeProgressRequestDto.java
+++ b/backend/src/main/java/com/ottproject/ottbackend/dto/EpisodeProgressRequestDto.java
@@ -1,0 +1,25 @@
+package com.ottproject.ottbackend.dto;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * 진행률 저장 요청 DTO
+ * - 현재 위치와 총 길이를 전달
+ */
+@Getter // 게터 생성
+@Setter // 세터 생성
+@NoArgsConstructor // 기본 생성자
+@AllArgsConstructor // 모든 필드 생성자
+public class EpisodeProgressRequestDto { // 진행률 저장 요청 DTO
+    @NotNull @Min(0)
+    private Integer positionSec; // 현재 위치(초)
+    @NotNull @Min(0)
+    private Integer durationSec; // 총 길이(초)
+}
+
+

--- a/backend/src/main/java/com/ottproject/ottbackend/dto/EpisodeProgressResponseDto.java
+++ b/backend/src/main/java/com/ottproject/ottbackend/dto/EpisodeProgressResponseDto.java
@@ -1,0 +1,25 @@
+package com.ottproject.ottbackend.dto;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * 진행률 응답 DTO
+ * - 진행 위치/총 길이/갱신 시각
+ */
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class EpisodeProgressResponseDto { // 진행률 공용 DTO(요청/응답 공통 필드)
+	private Integer positionSec; // 현재 위치(초)
+	private Integer durationSec; // 총 길이(초)
+	private LocalDateTime updatedAt; // 응답 시 사용, 요청 시 null 허용
+}
+
+

--- a/backend/src/main/java/com/ottproject/ottbackend/dto/SkipMetaResponseDto.java
+++ b/backend/src/main/java/com/ottproject/ottbackend/dto/SkipMetaResponseDto.java
@@ -1,0 +1,17 @@
+package com.ottproject.ottbackend.dto;
+
+import lombok.*;
+
+/**
+ * 스킵 메타 응답 DTO
+ * - 인트로/엔딩 구간(초)
+ */
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SkipMetaResponseDto { // 스킵 메타 응답
+    private Integer introStart; private Integer introEnd; // 인트로
+    private Integer outroStart; private Integer outroEnd; // 엔딩
+}

--- a/backend/src/main/java/com/ottproject/ottbackend/dto/SkipUsageRequestDto.java
+++ b/backend/src/main/java/com/ottproject/ottbackend/dto/SkipUsageRequestDto.java
@@ -1,0 +1,26 @@
+package com.ottproject.ottbackend.dto;
+
+import com.ottproject.ottbackend.enums.SkipType;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * 스킵 사용 로깅 요청 DTO
+ * - 사용 타입과 시점을 전달
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SkipUsageRequestDto { // 스킵 사용 로깅 요청
+    @NotNull
+    private SkipType type; // INTRO/OUTRO
+    @NotNull @Min(0)
+    private Integer atSec; // 사용 시점(초)
+}
+
+

--- a/backend/src/main/java/com/ottproject/ottbackend/dto/StreamUrlResponseDto.java
+++ b/backend/src/main/java/com/ottproject/ottbackend/dto/StreamUrlResponseDto.java
@@ -1,0 +1,16 @@
+package com.ottproject.ottbackend.dto;
+
+import lombok.*;
+
+/**
+ * 스트림 URL 응답 DTO
+ * - secure_link 파라미터 포함 m3u8 URL
+ */
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class StreamUrlResponseDto { // 스트림 URL 응답
+    private String url; // 서명된 master.m3u8 URL
+}

--- a/backend/src/main/java/com/ottproject/ottbackend/dto/UserSettingsDto.java
+++ b/backend/src/main/java/com/ottproject/ottbackend/dto/UserSettingsDto.java
@@ -1,0 +1,19 @@
+package com.ottproject.ottbackend.dto;
+
+import lombok.*;
+
+/**
+ * 사용자 재생 설정 DTO
+ * - 자동 스킵/기본 화질/자동 다음 화
+ */
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserSettingsDto { // 사용자 재생 설정
+    private Boolean autoSkipIntro; // 자동 인트로 스킵
+    private Boolean autoSkipEnding; // 자동 엔딩 스킵
+    private String defaultQuality; // 기본 화질
+    private Boolean autoNextEpisode; // 다음 화 자동재생
+}

--- a/backend/src/main/java/com/ottproject/ottbackend/entity/EpisodeProgress.java
+++ b/backend/src/main/java/com/ottproject/ottbackend/entity/EpisodeProgress.java
@@ -1,0 +1,49 @@
+package com.ottproject.ottbackend.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+/**
+ * 시청 진행률 엔티티
+ * - 사용자 × 에피소드 유니크
+ * - 마지막 수정 시각을 갱신하여 최근 시점을 노출
+ */
+@Entity // 진행률 저장 엔티티
+@Table(name = "episode_progress", uniqueConstraints = @UniqueConstraint(columnNames = {"user_id","episode_id"})) // 유니크
+@Getter
+@Setter
+@Builder @NoArgsConstructor
+@AllArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
+public class EpisodeProgress { // 시청 진행률
+
+	@Id @GeneratedValue(strategy = GenerationType.IDENTITY) // PK
+	private Long id; // PK
+
+	// 진행률 소유 사용자
+	@ManyToOne(fetch = FetchType.LAZY, optional = false) // 사용자
+	@JoinColumn(name = "user_id", nullable = false) // FK
+	private User user; // 사용자
+
+	// 진행률 대상 에피소드
+	@ManyToOne(fetch = FetchType.LAZY, optional = false) // 에피소드
+	@JoinColumn(name = "episode_id", nullable = false) // FK
+	private Episode episode; // 에피소드
+
+	// 현재 위치(초)
+	@Column(nullable = false) // 진행 위치(초)
+	private Integer positionSec; // 현재 위치
+
+	// 총 길이(초)
+	@Column(nullable = false) // 총 길이(초)
+	private Integer durationSec; // 총 길이
+
+	// 최신 갱신 시각
+	@LastModifiedDate
+	@Column(nullable = false) @Builder.Default // 수정 시각
+	private LocalDateTime updatedAt = LocalDateTime.now(); // 갱신 시각
+}

--- a/backend/src/main/java/com/ottproject/ottbackend/entity/EpisodeSkipMeta.java
+++ b/backend/src/main/java/com/ottproject/ottbackend/entity/EpisodeSkipMeta.java
@@ -1,0 +1,39 @@
+package com.ottproject.ottbackend.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+/**
+ * 에피소드 스킵 구간 메타 엔티티
+ * - 인트로/엔딩 구간(초) 저장
+ */
+@Entity // 스킵 구간 메타
+@Table(name = "episode_skip_meta", uniqueConstraints = @UniqueConstraint(columnNames = {"episode_id"})) // 1:1
+@Getter
+@Setter
+@Builder @NoArgsConstructor
+@AllArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
+public class EpisodeSkipMeta { // 오프닝/엔딩 구간
+
+	@Id @GeneratedValue(strategy = GenerationType.IDENTITY) // PK
+	private Long id; // PK
+
+	// 대상 에피소드(1:1)
+	@OneToOne(fetch = FetchType.LAZY, optional = false) // 에피소드 1:1
+	@JoinColumn(name = "episode_id", nullable = false) // FK
+	private Episode episode; // 에피소드
+
+	@Column(nullable = true) private Integer introStart; // 인트로 시작(초)
+	@Column(nullable = true) private Integer introEnd;   // 인트로 종료(초)
+	@Column(nullable = true) private Integer outroStart; // 엔딩 시작(초)
+	@Column(nullable = true) private Integer outroEnd;   // 엔딩 종료(초)
+
+	@LastModifiedDate
+	@Column(nullable = false) @Builder.Default // 갱신 시각
+	private LocalDateTime updatedAt = LocalDateTime.now(); // 갱신
+}

--- a/backend/src/main/java/com/ottproject/ottbackend/entity/Plan.java
+++ b/backend/src/main/java/com/ottproject/ottbackend/entity/Plan.java
@@ -1,0 +1,31 @@
+package com.ottproject.ottbackend.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+/**
+ * 구독 플랜 엔티티
+ * - 코드/표기명/허용 최대 화질
+ */
+@Entity
+@Table(name = "plans")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Plan { // 구독 플랜
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id; // PK
+
+    @Column(nullable = false, unique = true)
+    private String code; // e.g., FREE, BASIC, PREMIUM
+
+    @Column(nullable = false)
+    private String name; // 표기명
+
+    @Column(nullable = false)
+    private String maxQuality; // "720p" / "1080p"
+}
+
+

--- a/backend/src/main/java/com/ottproject/ottbackend/entity/SkipUsage.java
+++ b/backend/src/main/java/com/ottproject/ottbackend/entity/SkipUsage.java
@@ -1,0 +1,56 @@
+package com.ottproject.ottbackend.entity;
+
+import com.ottproject.ottbackend.enums.SkipType;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+/**
+ * 스킵 사용 로그 엔티티
+ * - 비로그인 사용도 기록 가능(user null)
+ */
+@Entity
+@Table(name = "skip_usage")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
+public class SkipUsage { // 스킵 사용 로그
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id; // PK
+
+    // 사용한 사용자(null 가능)
+    @ManyToOne(fetch = FetchType.LAZY, optional = true)
+    @JoinColumn(name = "user_id")
+    private User user; // null 허용(비로그인)
+
+    // 대상 에피소드
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "episode_id", nullable = false)
+    private Episode episode; // 대상
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private com.ottproject.ottbackend.enums.SkipType type; // INTRO/OUTRO
+
+    @Column(nullable = false)
+    private Integer atSec; // 시점(초)
+
+    @CreatedDate
+    @Column(nullable = false)
+    @Builder.Default
+    private java.time.LocalDateTime createdAt = java.time.LocalDateTime.now(); // 생성 시각
+}
+
+

--- a/backend/src/main/java/com/ottproject/ottbackend/entity/Subscription.java
+++ b/backend/src/main/java/com/ottproject/ottbackend/entity/Subscription.java
@@ -1,0 +1,44 @@
+package com.ottproject.ottbackend.entity;
+
+import com.ottproject.ottbackend.enums.SubscriptionStatus;
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDateTime;
+
+/**
+ * 사용자 구독 엔티티
+ * - 구독 플랜/상태/기간 관리
+ */
+@Entity
+@Table(name = "subscriptions", indexes = {
+        @Index(name = "idx_subscription_user", columnList = "user_id")
+})
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Subscription { // 사용자 구독
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id; // PK
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user; // 소유자
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "plan_id", nullable = false)
+    private Plan plan; // 플랜
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private com.ottproject.ottbackend.enums.SubscriptionStatus status; // 상태
+
+    @Column(nullable = false)
+    private java.time.LocalDateTime startAt; // 시작 시각
+
+    @Column(nullable = true)
+    private java.time.LocalDateTime endAt; // 종료 시각(null=무기한)
+}
+
+

--- a/backend/src/main/java/com/ottproject/ottbackend/entity/UserSettings.java
+++ b/backend/src/main/java/com/ottproject/ottbackend/entity/UserSettings.java
@@ -1,0 +1,45 @@
+package com.ottproject.ottbackend.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+/**
+ * 사용자 재생 설정 엔티티
+ * - 자동 스킵/기본 화질/자동 다음 화 설정
+ */
+@Entity // 재생 설정 엔티티
+@Table(name = "user_settings", uniqueConstraints = @UniqueConstraint(columnNames = {"user_id"})) // 유니크
+@Getter
+@Setter
+@Builder @NoArgsConstructor
+@AllArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
+public class UserSettings { // 사용자 재생 설정
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY) // PK
+    private Long id; // PK
+
+    @OneToOne(fetch = FetchType.LAZY, optional = false) // 1:1 사용자
+    @JoinColumn(name = "user_id", nullable = false) // FK
+    private User user; // 사용자
+
+    @Column(nullable = false) @Builder.Default // 자동 스킵
+    private Boolean autoSkipIntro = true; // 오프닝 자동 스킵
+
+    @Column(nullable = false) @Builder.Default // 자동 스킵
+    private Boolean autoSkipEnding = true; // 엔딩 자동 스킵
+
+    @Column(nullable = false) @Builder.Default // 기본 화질
+    private String defaultQuality = "auto"; // auto|480p|720p|1080p
+
+    @Column(nullable = false) @Builder.Default // 다음 화 자동재생
+    private Boolean autoNextEpisode = true; // 자동 다음 화
+
+    @LastModifiedDate
+    @Column(nullable = false) @Builder.Default // 갱신 시각
+    private LocalDateTime updatedAt = LocalDateTime.now(); // 갱신
+}

--- a/backend/src/main/java/com/ottproject/ottbackend/enums/SkipType.java
+++ b/backend/src/main/java/com/ottproject/ottbackend/enums/SkipType.java
@@ -1,0 +1,13 @@
+package com.ottproject.ottbackend.enums;
+
+/**
+ * 스킵 타입
+ * - INTRO: 오프닝
+ * - OUTRO: 엔딩
+ */
+public enum SkipType { // 스킵 타입
+    INTRO, // 오프닝
+    OUTRO  // 엔딩
+}
+
+

--- a/backend/src/main/java/com/ottproject/ottbackend/enums/SubscriptionStatus.java
+++ b/backend/src/main/java/com/ottproject/ottbackend/enums/SubscriptionStatus.java
@@ -1,0 +1,15 @@
+package com.ottproject.ottbackend.enums;
+
+/**
+ * 구독 상태
+ * - ACTIVE: 활성
+ * - CANCELED: 해지
+ * - EXPIRED: 만료
+ */
+public enum SubscriptionStatus {
+    ACTIVE,
+    CANCELED,
+    EXPIRED
+}
+
+

--- a/backend/src/main/java/com/ottproject/ottbackend/exception/ApiError.java
+++ b/backend/src/main/java/com/ottproject/ottbackend/exception/ApiError.java
@@ -1,0 +1,17 @@
+package com.ottproject.ottbackend.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ApiError {
+    private String code;
+    private String message;
+}
+
+

--- a/backend/src/main/java/com/ottproject/ottbackend/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/ottproject/ottbackend/exception/GlobalExceptionHandler.java
@@ -1,0 +1,36 @@
+package com.ottproject.ottbackend.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.server.ResponseStatusException;
+
+/**
+ * 전역 예외 핸들러
+ * - 표준 에러 포맷으로 변환하여 응답
+ */
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+	@ExceptionHandler(ResponseStatusException.class)
+	public ResponseEntity<ApiError> handleRse(ResponseStatusException ex) {
+		HttpStatus status = ex.getStatusCode() instanceof HttpStatus ? (HttpStatus) ex.getStatusCode() : HttpStatus.BAD_REQUEST; // 상태 추출
+		return ResponseEntity.status(status).body(ApiError.builder().code("ERROR") .message(ex.getReason()).build()); // 코드/메시지 응답
+	}
+
+	@ExceptionHandler(MethodArgumentNotValidException.class)
+	public ResponseEntity<ApiError> handleValidation(MethodArgumentNotValidException ex) {
+		String msg = ex.getBindingResult().getFieldErrors().stream()
+				.findFirst().map(err -> err.getField() + ": " + err.getDefaultMessage()).orElse("Validation error"); // 첫 에러 메시지
+		return ResponseEntity.badRequest().body(ApiError.builder().code("VALIDATION_ERROR").message(msg).build()); // 400 + 메시지
+	}
+
+	@ExceptionHandler(Exception.class)
+	public ResponseEntity<ApiError> handleAny(Exception ex) {
+		return ResponseEntity.status(500).body(ApiError.builder().code("INTERNAL_ERROR").message("Internal server error").build()); // 500 일반 에러
+	}
+}
+
+

--- a/backend/src/main/java/com/ottproject/ottbackend/repository/EpisodeProgressRepository.java
+++ b/backend/src/main/java/com/ottproject/ottbackend/repository/EpisodeProgressRepository.java
@@ -1,0 +1,19 @@
+package com.ottproject.ottbackend.repository;
+
+import com.ottproject.ottbackend.entity.EpisodeProgress;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * 진행률 리포지토리
+ * - 사용자/에피소드별 단건 및 벌크 조회 제공
+ */
+@Repository
+public interface EpisodeProgressRepository extends JpaRepository<EpisodeProgress, Long> { // 진행률
+	Optional<EpisodeProgress> findByUser_IdAndEpisode_Id(Long userId, Long episodeId); // 단건
+	List<EpisodeProgress> findByUser_IdAndEpisode_IdIn(Long userId, Collection<Long> episodeIds); // 벌크
+}

--- a/backend/src/main/java/com/ottproject/ottbackend/repository/EpisodeRepository.java
+++ b/backend/src/main/java/com/ottproject/ottbackend/repository/EpisodeRepository.java
@@ -13,7 +13,7 @@ import java.util.Optional;
 
 /**
  * Episode CUD 전용 리포지토리
- * - 에피소드 생성/수정/삭제만 담당 (에피소드 목록/조회는 MyBatis)
+ * - 에피소드 생성/수정/삭제 전용 (목록/조회는 MyBatis)
  */
 @Repository // 스프링 빈 등록
 public interface EpisodeRepository extends JpaRepository<Episode, Long> { // 에피소드 CUD
@@ -25,4 +25,7 @@ public interface EpisodeRepository extends JpaRepository<Episode, Long> { // 에
     @Modifying(clearAutomatically = true, flushAutomatically = true) // DML + 동기화
     @Query("delete from Episode e where e.aniDetail.id = :aniDetailId") // 상세에 속한 에피소드 전체 삭제
     int deleteByAniDetailId(@Param("aniDetailId") Long aniDetailId); // 삭제 행 수
+
+    // 다음 화 조회(동일 AniDetail 기준, 공개된 것만)
+    Episode findFirstByAniDetailIdAndEpisodeNumberGreaterThanAndIsReleasedTrueOrderByEpisodeNumberAsc(Long aniDetailId, Integer episodeNumber);
 }

--- a/backend/src/main/java/com/ottproject/ottbackend/repository/EpisodeSkipMetaRepository.java
+++ b/backend/src/main/java/com/ottproject/ottbackend/repository/EpisodeSkipMetaRepository.java
@@ -1,0 +1,16 @@
+package com.ottproject.ottbackend.repository;
+
+import com.ottproject.ottbackend.entity.EpisodeSkipMeta;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+/**
+ * 스킵 메타 리포지토리
+ * - 에피소드별 1:1 메타 조회
+ */
+@Repository
+public interface EpisodeSkipMetaRepository extends JpaRepository<EpisodeSkipMeta, Long> { // 스킵 메타
+    Optional<EpisodeSkipMeta> findByEpisodeId(Long episodeId); // 1:1
+}

--- a/backend/src/main/java/com/ottproject/ottbackend/repository/PlanRepository.java
+++ b/backend/src/main/java/com/ottproject/ottbackend/repository/PlanRepository.java
@@ -1,0 +1,17 @@
+package com.ottproject.ottbackend.repository;
+
+import com.ottproject.ottbackend.entity.Plan;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+/**
+ * 플랜 리포지토리
+ */
+@Repository
+public interface PlanRepository extends JpaRepository<Plan, Long> {
+    Optional<Plan> findByCode(String code);
+}
+
+

--- a/backend/src/main/java/com/ottproject/ottbackend/repository/SkipUsageRepository.java
+++ b/backend/src/main/java/com/ottproject/ottbackend/repository/SkipUsageRepository.java
@@ -1,0 +1,13 @@
+package com.ottproject.ottbackend.repository;
+
+import com.ottproject.ottbackend.entity.SkipUsage;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * 스킵 사용 로그 리포지토리
+ */
+@Repository
+public interface SkipUsageRepository extends JpaRepository<SkipUsage, Long> { }
+
+

--- a/backend/src/main/java/com/ottproject/ottbackend/repository/SubscriptionRepository.java
+++ b/backend/src/main/java/com/ottproject/ottbackend/repository/SubscriptionRepository.java
@@ -1,0 +1,21 @@
+package com.ottproject.ottbackend.repository;
+
+import com.ottproject.ottbackend.entity.Subscription;
+import com.ottproject.ottbackend.enums.SubscriptionStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+/**
+ * 구독 리포지토리
+ * - 사용자 활성 구독(기간 유효) 조회
+ */
+@Repository
+public interface SubscriptionRepository extends JpaRepository<Subscription, Long> {
+	Optional<Subscription> findFirstByUser_IdAndStatusAndStartAtBeforeAndEndAtAfterOrEndAtIsNullOrderByStartAtDesc(
+			Long userId, SubscriptionStatus status, LocalDateTime now1, LocalDateTime now2); // 가장 최근 시작된 유효 구독
+}
+
+

--- a/backend/src/main/java/com/ottproject/ottbackend/repository/UserSettingsRepository.java
+++ b/backend/src/main/java/com/ottproject/ottbackend/repository/UserSettingsRepository.java
@@ -1,0 +1,15 @@
+package com.ottproject.ottbackend.repository;
+
+import com.ottproject.ottbackend.entity.UserSettings;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+/**
+ * 사용자 재생 설정 리포지토리
+ */
+@Repository // 스프링 빈 등록
+public interface UserSettingsRepository extends JpaRepository<UserSettings, Long> { // 설정 리포지토리
+	Optional<UserSettings> findByUserId(Long userId); // user.id 경로 탐색
+}

--- a/backend/src/main/java/com/ottproject/ottbackend/service/MembershipService.java
+++ b/backend/src/main/java/com/ottproject/ottbackend/service/MembershipService.java
@@ -1,0 +1,12 @@
+package com.ottproject.ottbackend.service;
+
+/**
+ * 멤버십 판별 추상화
+ * - 구현체에 따라 멤버십 여부/허용 화질 상한을 결정
+ */
+public interface MembershipService { // 멤버십 판별 추상화
+	boolean isMember(Long userId);
+	String allowedMaxQuality(Long userId); // "1080p" | "720p"
+}
+
+

--- a/backend/src/main/java/com/ottproject/ottbackend/service/PlayerAuthService.java
+++ b/backend/src/main/java/com/ottproject/ottbackend/service/PlayerAuthService.java
@@ -1,0 +1,80 @@
+package com.ottproject.ottbackend.service;
+
+import com.ottproject.ottbackend.repository.AniListRepository;
+import com.ottproject.ottbackend.repository.EpisodeRepository;
+import com.ottproject.ottbackend.repository.UserRepository;
+import com.ottproject.ottbackend.util.SecureLinkUtil;
+import com.ottproject.ottbackend.service.MembershipService;
+import org.springframework.transaction.annotation.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+/**
+ * 재생 권한 검사 및 스트림 URL 생성 서비스
+ * - 1~3화 무료 규칙 적용
+ * - 멤버십 여부로 720p/1080p 분기
+ * - Nginx secure_link 기반 만료/서명 URL 생성
+ */
+@Service
+@RequiredArgsConstructor
+public class PlayerAuthService { // 재생 권한/URL 발급
+	private final UserRepository userRepository; // 권한 확인(멤버십 여부 판단용)
+	private final MembershipService membershipService; // 멤버십 추상화
+	private final AniListRepository aniListRepository; // 작품 소속 판단(에피소드 → ani)
+	private final EpisodeRepository episodeRepository; // 에피소드 조회(존재/소속)
+
+	/**
+	 * 사용자의 특정 에피소드 재생 가능 여부 판단
+	 */
+	@Transactional(readOnly = true)
+	public boolean canStream(Long userId, Long episodeId) { // 권한 검사
+		if (userId == null) return false; // 미로그인 차단
+
+		var episode = episodeRepository.findById(episodeId).orElse(null); // 에피소드 조회
+		if (episode == null || Boolean.FALSE.equals(episode.getIsActive()) || Boolean.FALSE.equals(episode.getIsReleased())) {
+			return false; // 비활성/미공개 차단
+		}
+
+		Integer epNo = episode.getEpisodeNumber(); // 화수
+		if (epNo != null && epNo <= 3) return true; // 1~3화 무료
+
+		return membershipService.isMember(userId); // 4화 이상은 멤버십 필요
+	}
+
+	/**
+	 * Nginx secure_link 기반 m3u8 서명 URL 생성
+	 */
+	@Transactional(readOnly = true)
+	public String buildSignedStreamUrl(Long userId, Long episodeId) { // 서명URL 생성
+		var episode = episodeRepository.findById(episodeId).orElseThrow(); // 에피소드 존재 보장
+		boolean isMember = membershipService.isMember(userId); // 멤버십 여부
+
+		String absolute = episode.getVideoUrl(); // 원본 절대 URL
+		String filtered = isMember ? absolute : absolute.replace("master.m3u8", "master_720p.m3u8"); // 품질 제한 분기
+
+		String uriPath = filtered.replaceFirst("https?://[^/]+", ""); // 도메인 제거해 path 추출
+
+		long expires = SecureLinkUtil.defaultExpiryFromNowSeconds(600); // TTL 10분
+		String secret = System.getProperty("secure.link.secret", System.getenv().getOrDefault("SECURE_LINK_SECRET", "change_me")); // 시크릿 로드
+		String st = SecureLinkUtil.generateSignature(uriPath, expires, secret); // 서명 생성
+
+		String join = filtered.contains("?") ? "&" : "?"; // 쿼리 구분자
+		return filtered + join + "e=" + expires + "&st=" + st; // 최종 URL 반환
+	}
+
+	/**
+	 * 현재 화 기준 다음 화 ID 조회(공개된 것만)
+	 */
+	@Transactional(readOnly = true)
+	public Long nextEpisodeId(Long currentEpisodeId) { // 다음 화 조회
+		var current = episodeRepository.findById(currentEpisodeId).orElse(null); // 현재 화
+		if (current == null || current.getAniDetail() == null) {
+			return null; // 없으면 null
+		}
+		var next = episodeRepository
+				.findFirstByAniDetailIdAndEpisodeNumberGreaterThanAndIsReleasedTrueOrderByEpisodeNumberAsc(
+						current.getAniDetail().getId(), current.getEpisodeNumber()
+				); // 다음 화 탐색
+		return (next != null) ? next.getId() : null; // 다음 화 ID 또는 null
+	}
+}

--- a/backend/src/main/java/com/ottproject/ottbackend/service/ProgressService.java
+++ b/backend/src/main/java/com/ottproject/ottbackend/service/ProgressService.java
@@ -1,0 +1,69 @@
+package com.ottproject.ottbackend.service;
+
+import com.ottproject.ottbackend.dto.EpisodeProgressResponseDto;
+import com.ottproject.ottbackend.entity.EpisodeProgress;
+import com.ottproject.ottbackend.repository.EpisodeProgressRepository;
+import com.ottproject.ottbackend.repository.EpisodeRepository;
+import com.ottproject.ottbackend.repository.UserRepository;
+import org.springframework.transaction.annotation.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+/**
+ * 시청 진행률 저장/조회 서비스
+ * - upsert 멱등 저장
+ * - 단건/벌크 조회 제공
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ProgressService { // 진행률 저장/조회
+	private final EpisodeProgressRepository repo; // 진행률
+	private final UserRepository userRepo; private final EpisodeRepository episodeRepo; // 참조 조회
+
+	/**
+	 * 진행률 멱등 저장(있으면 갱신, 없으면 생성)
+	 */
+	public void upsert(Long userId, Long episodeId, int pos, int dur) { // 멱등 저장
+		EpisodeProgress entity = repo.findByUser_IdAndEpisode_Id(userId, episodeId) // 기존 진행률 조회
+				.orElseGet(() -> EpisodeProgress.builder()
+						.user(userRepo.findById(userId).orElseThrow()) // 사용자 로드
+						.episode(episodeRepo.findById(episodeId).orElseThrow()) // 에피소드 로드
+						.positionSec(0).durationSec(0).build()); // 초기값
+		entity.setPositionSec(pos); entity.setDurationSec(dur); // 값 갱신
+		repo.save(entity); // 저장
+	}
+
+	/**
+	 * 진행률 단건 조회
+	 */
+	@Transactional(readOnly = true)
+	public java.util.Optional<EpisodeProgressResponseDto> find(Long userId, Long episodeId) { // 단건 조회
+		return repo.findByUser_IdAndEpisode_Id(userId, episodeId) // 진행률 조회
+				.map(p -> EpisodeProgressResponseDto.builder()
+						.positionSec(p.getPositionSec()) // 현재 위치
+						.durationSec(p.getDurationSec()) // 총 길이
+						.updatedAt(p.getUpdatedAt()) // 갱신 시각
+						.build()); // DTO 변환
+	}
+
+	/**
+	 * 진행률 벌크 조회(에피소드 ID 집합)
+	 */
+	@Transactional(readOnly = true)
+	public java.util.Map<Long, EpisodeProgressResponseDto> findBulk(Long userId, java.util.Collection<Long> episodeIds) {
+		java.util.List<EpisodeProgress> list = repo.findByUser_IdAndEpisode_IdIn(userId, episodeIds); // 일괄 조회
+		java.util.Map<Long, EpisodeProgressResponseDto> map = new java.util.HashMap<>(); // 결과 맵
+		for (EpisodeProgress p : list) { // 각 진행률 변환
+			map.put(
+					p.getEpisode().getId(), // 키: 에피소드 ID
+					EpisodeProgressResponseDto.builder()
+							.positionSec(p.getPositionSec())
+							.durationSec(p.getDurationSec())
+							.updatedAt(p.getUpdatedAt())
+							.build()
+			); // 값: DTO
+		}
+		return map; // 맵 반환
+	}
+}

--- a/backend/src/main/java/com/ottproject/ottbackend/service/SettingsService.java
+++ b/backend/src/main/java/com/ottproject/ottbackend/service/SettingsService.java
@@ -1,0 +1,49 @@
+package com.ottproject.ottbackend.service;
+
+import com.ottproject.ottbackend.dto.UserSettingsDto;
+import com.ottproject.ottbackend.entity.UserSettings;
+import com.ottproject.ottbackend.repository.UserRepository;
+import com.ottproject.ottbackend.repository.UserSettingsRepository;
+import org.springframework.transaction.annotation.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+/**
+ * 사용자 재생 설정 서비스
+ * - 기본값 제공, 선택적 필드 업데이트
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class SettingsService { // 사용자 재생 설정
+	private final UserSettingsRepository repo; private final UserRepository userRepo; // 의존성
+
+	/**
+	 * 사용자 설정 조회(없으면 기본값 반환)
+	 */
+	@Transactional(readOnly = true)
+	public UserSettingsDto get(Long userId) {
+		return repo.findByUserId(userId) // 1:1 설정 조회
+				.map(u -> UserSettingsDto.builder()
+						.autoSkipIntro(u.getAutoSkipIntro())
+						.autoSkipEnding(u.getAutoSkipEnding())
+						.defaultQuality(u.getDefaultQuality())
+						.autoNextEpisode(u.getAutoNextEpisode())
+						.build())
+				.orElse(UserSettingsDto.builder()
+						.autoSkipIntro(true).autoSkipEnding(true).defaultQuality("auto").autoNextEpisode(true)
+						.build()); // 기본값
+	}
+	/**
+	 * 사용자 설정 업데이트(부분 갱신)
+	 */
+	public void update(Long userId, UserSettingsDto dto) {
+		UserSettings entity = repo.findByUserId(userId)
+				.orElseGet(() -> UserSettings.builder().user(userRepo.findById(userId).orElseThrow()).build()); // 없으면 생성
+		if (dto.getAutoSkipIntro()!=null) entity.setAutoSkipIntro(dto.getAutoSkipIntro()); // 인트로
+		if (dto.getAutoSkipEnding()!=null) entity.setAutoSkipEnding(dto.getAutoSkipEnding()); // 엔딩
+		if (dto.getDefaultQuality()!=null) entity.setDefaultQuality(dto.getDefaultQuality()); // 화질
+		if (dto.getAutoNextEpisode()!=null) entity.setAutoNextEpisode(dto.getAutoNextEpisode()); // 자동 다음화
+		repo.save(entity); // 저장
+	}
+}

--- a/backend/src/main/java/com/ottproject/ottbackend/service/SkipService.java
+++ b/backend/src/main/java/com/ottproject/ottbackend/service/SkipService.java
@@ -1,0 +1,52 @@
+package com.ottproject.ottbackend.service;
+
+import com.ottproject.ottbackend.dto.SkipMetaResponseDto;
+import com.ottproject.ottbackend.enums.SkipType;
+import com.ottproject.ottbackend.entity.SkipUsage;
+import com.ottproject.ottbackend.repository.EpisodeRepository;
+import com.ottproject.ottbackend.repository.EpisodeSkipMetaRepository;
+import com.ottproject.ottbackend.repository.SkipUsageRepository;
+import com.ottproject.ottbackend.repository.UserRepository;
+import org.springframework.transaction.annotation.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+/**
+ * 스킵 메타 조회 및 사용 로깅 서비스
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class SkipService { // 스킵 메타 조회
+	private final EpisodeSkipMetaRepository repo; // 메타 리포지토리
+	private final SkipUsageRepository skipUsageRepository; // 사용 로그 리포지토리
+	private final UserRepository userRepository; // 사용자 조회
+	private final EpisodeRepository episodeRepository; // 에피소드 조회
+	public SkipMetaResponseDto get(Long episodeId) { // 메타 조회
+		return repo.findByEpisodeId(episodeId)
+				.map(m -> new SkipMetaResponseDto(m.getIntroStart(), m.getIntroEnd(), m.getOutroStart(), m.getOutroEnd())) // DTO 변환
+				.orElse(new SkipMetaResponseDto(null,null,null,null)); // 없으면 null 필드 반환
+	}
+
+	// 통계/로그 적재: 간단 DB 저장
+	@Transactional
+	public void trackUsage(Long userId, Long episodeId, SkipType type, Integer atSec) {
+		var usage = SkipUsage.builder() // 엔티티 빌드
+					.user(userId != null ? userRepository.findById(userId).orElse(null) : null) // 사용자(비로그인 null)
+					.episode(episodeRepository.findById(episodeId).orElseThrow()) // 에피소드 로드
+					.type(type) // 타입
+					.atSec(atSec) // 시점
+					.build();
+		skipUsageRepository.save(usage); // 저장
+	}
+
+	@Transactional
+	public void trackUsage(Long userId, Long episodeId, String type, Integer atSec) { // 문자열 타입 오버로드
+		SkipType t = null; // 파싱 결과
+		if (type != null) {
+			try { t = SkipType.valueOf(type.toUpperCase()); } catch (IllegalArgumentException ignored) {} // 안전 파싱
+		}
+		if (t == null) return; // 유효하지 않으면 무시
+		trackUsage(userId, episodeId, t, atSec); // 위 메서드 재사용
+	}
+}

--- a/backend/src/main/java/com/ottproject/ottbackend/service/SubscriptionMembershipService.java
+++ b/backend/src/main/java/com/ottproject/ottbackend/service/SubscriptionMembershipService.java
@@ -1,0 +1,37 @@
+package com.ottproject.ottbackend.service;
+
+import com.ottproject.ottbackend.enums.SubscriptionStatus;
+import com.ottproject.ottbackend.repository.SubscriptionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+/**
+ * 구독 기반 멤버십 판별 서비스 구현
+ * - ACTIVE 상태이며 기간 유효한 구독 존재 시 멤버십 인정
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class SubscriptionMembershipService implements MembershipService { // 실제 멤버십 연동 기본 구현
+	private final SubscriptionRepository subscriptionRepository; // 구독 조회 리포지토리
+
+	@Override
+	public boolean isMember(Long userId) {
+		if (userId == null) return false; // 미로그인 비회원
+		var now = LocalDateTime.now(); // 현재 시각
+		return subscriptionRepository
+				.findFirstByUser_IdAndStatusAndStartAtBeforeAndEndAtAfterOrEndAtIsNullOrderByStartAtDesc(
+						userId, SubscriptionStatus.ACTIVE, now, now
+				).isPresent(); // 유효 구독 존재 여부
+	}
+
+	@Override
+	public String allowedMaxQuality(Long userId) {
+		return isMember(userId) ? "1080p" : "720p"; // 멤버십 화질 상한
+	}
+}
+
+

--- a/backend/src/main/java/com/ottproject/ottbackend/util/SecureLinkUtil.java
+++ b/backend/src/main/java/com/ottproject/ottbackend/util/SecureLinkUtil.java
@@ -1,0 +1,39 @@
+package com.ottproject.ottbackend.util;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Instant;
+import java.util.Base64;
+
+/**
+ * Nginx secure_link 서명 유틸리티
+ * - MD5 기반 서명(st)과 만료 시각(e) 계산
+ */
+public final class SecureLinkUtil { // Nginx secure_link 서명 유틸리티
+    private SecureLinkUtil() {} // 인스턴스화 방지
+
+    /**
+     * secure_link 서명값(st) 생성
+     * - 포맷: MD5(expires + uriPath + " " + secret) → Base64
+     */
+    public static String generateSignature(String uriPath, long expiresEpochSeconds, String secret) {
+        String data = expiresEpochSeconds + uriPath + " " + secret; // Nginx 측과 동일한 연결 문자열
+        byte[] md5;
+        try {
+            md5 = MessageDigest.getInstance("MD5").digest(data.getBytes(StandardCharsets.UTF_8)); // MD5 해시
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("MD5 algorithm not available", e); // 환경 문제 시 런타임 예외
+        }
+        return Base64.getEncoder().encodeToString(md5); // Base64 인코딩(패딩 포함)
+    }
+
+    /**
+     * 현재 시각 기준 TTL초 뒤 만료 시각(epoch seconds) 계산
+     */
+    public static long defaultExpiryFromNowSeconds(long ttlSeconds) {
+        return Instant.now().getEpochSecond() + Math.max(1, ttlSeconds); // 최소 1초 보장
+    }
+}
+
+


### PR DESCRIPTION
feat: Added CORS settings (MvcConfig) and reflected Skip/OpenAPI path permitAll (WebSecurityConfig)
feat: Added Progress/SkipMeta/SkipUse/Settings/Plan/Subscription entities and configured schema
feat: Added Progress/Skip/Stream/Settings DTOs and applied Bean Validation
feat: Added Progress/SkipMeta/SkipUse/Settings/Plan/Subscription repositories and enhanced the next episode retrieval method
feat: Implemented playback rights/signature URL (PlayerAuth), progress (Upsert/Retrieval), skip (meta/logging), and settings services, and added membership abstraction/implementation
feat: Added GET/PUT endpoints for stream URL, progress (save/retrieval/bulk), next episode, skip meta/tracking, and settings
feat: Added skip type and subscription status enums
feat: Added global exception handling and a standard error response schema (ApiError)
feat: Added Nginx secure_link signing utility (SecureLinkUtil)