### PR TITLE
Feat/frontend backend integration

### DIFF
--- a/backend/src/main/java/com/ottproject/ottbackend/controller/AnimeController.java
+++ b/backend/src/main/java/com/ottproject/ottbackend/controller/AnimeController.java
@@ -200,6 +200,27 @@ public class AnimeController { // 애니 목록/상세 조회 컨트롤러
         return queryService.getAllTags();
     }
 
+    @Operation(summary = "시즌 목록", description = "애니메이션에 존재하는 시즌 목록을 반환합니다.")
+    @ApiResponse(responseCode = "200", description = "조회 성공")
+    @GetMapping("/seasons")
+    public List<String> getSeasons() {
+        return queryService.getAllSeasons();
+    }
+
+    @Operation(summary = "상태 목록", description = "애니메이션 방영 상태 목록을 반환합니다.")
+    @ApiResponse(responseCode = "200", description = "조회 성공")
+    @GetMapping("/statuses")
+    public List<com.ottproject.ottbackend.dto.StatusOptionDto> getStatuses() {
+        return queryService.getAllStatuses();
+    }
+
+    @Operation(summary = "타입 목록", description = "애니메이션 출시 타입 목록을 반환합니다.")
+    @ApiResponse(responseCode = "200", description = "조회 성공")
+    @GetMapping("/types")
+    public List<com.ottproject.ottbackend.dto.TypeOptionDto> getTypes() {
+        return queryService.getAllTypes();
+    }
+
     /**
      * 사용자 활동 기록 (개인화 추천용)
      */

--- a/backend/src/main/java/com/ottproject/ottbackend/dto/StatusOptionDto.java
+++ b/backend/src/main/java/com/ottproject/ottbackend/dto/StatusOptionDto.java
@@ -1,0 +1,22 @@
+package com.ottproject.ottbackend.dto;
+
+import lombok.*;
+
+/**
+ * 상태 옵션 DTO
+ *
+ * 큰 흐름
+ * - 필터 옵션 표시를 위한 최소 데이터를 제공한다.
+ *
+ * 필드 개요
+ * - key/label: 식별/명칭
+ */
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class StatusOptionDto {
+    private String key; // ONGOING, COMPLETED, etc.
+    private String label; // 방영중, 완결, etc.
+}

--- a/backend/src/main/java/com/ottproject/ottbackend/dto/TypeOptionDto.java
+++ b/backend/src/main/java/com/ottproject/ottbackend/dto/TypeOptionDto.java
@@ -1,0 +1,22 @@
+package com.ottproject.ottbackend.dto;
+
+import lombok.*;
+
+/**
+ * 타입 옵션 DTO
+ *
+ * 큰 흐름
+ * - 필터 옵션 표시를 위한 최소 데이터를 제공한다.
+ *
+ * 필드 개요
+ * - key/label: 식별/명칭
+ */
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TypeOptionDto {
+    private String key; // TV, MOVIE, etc.
+    private String label; // TV, MOVIE, etc.
+}

--- a/backend/src/main/java/com/ottproject/ottbackend/mybatis/AnimeQueryMapper.java
+++ b/backend/src/main/java/com/ottproject/ottbackend/mybatis/AnimeQueryMapper.java
@@ -89,6 +89,11 @@ public interface AnimeQueryMapper { // 목록 상세/연관 조회 정의
     List<GenreSimpleDto> findAllGenres();
     List<TagSimpleDto> findAllTags();
 
+    // 필터 옵션 목록
+    List<String> findAllSeasons(); // 시즌 목록
+    List<StatusOptionDto> findAllStatuses(); // 상태 목록  
+    List<TypeOptionDto> findAllTypes(); // 타입 목록
+
     // 개인화 추천용 메서드들
     List<Long> findFavoriteAnimeIds(@Param("userId") Long userId); // 사용자 찜한 작품 ID 목록
     List<Long> findWatchedAnimeIds(@Param("userId") Long userId); // 사용자 시청한 작품 ID 목록

--- a/backend/src/main/java/com/ottproject/ottbackend/service/AnimeQueryService.java
+++ b/backend/src/main/java/com/ottproject/ottbackend/service/AnimeQueryService.java
@@ -141,6 +141,18 @@ public class AnimeQueryService { // 애니 조회 관련 비즈니스 로직 제
 		return mapper.findAllTags();
 	}
 
+	public java.util.List<String> getAllSeasons() {
+		return mapper.findAllSeasons();
+	}
+
+	public java.util.List<com.ottproject.ottbackend.dto.StatusOptionDto> getAllStatuses() {
+		return mapper.findAllStatuses();
+	}
+
+	public java.util.List<com.ottproject.ottbackend.dto.TypeOptionDto> getAllTypes() {
+		return mapper.findAllTypes();
+	}
+
 	/**
 	 * ID 목록으로 카드 리스트 조회 (입력 ID 순서 보존)
 	 */

--- a/backend/src/main/resources/mappers/AnimeQueryMapper.xml
+++ b/backend/src/main/resources/mappers/AnimeQueryMapper.xml
@@ -315,7 +315,42 @@
         t.name AS name,
         t.color AS color
         FROM tags t
+        WHERE t.is_active = TRUE
         ORDER BY t.name ASC
+    </select>
+
+    <!-- 마스터: 전체 시즌 목록 -->
+    <select id="findAllSeasons" resultType="java.lang.String">
+        SELECT DISTINCT season
+        FROM anime
+        WHERE is_active = TRUE AND season IS NOT NULL
+        ORDER BY season DESC
+    </select>
+
+    <!-- 마스터: 전체 상태 목록 -->
+    <select id="findAllStatuses" resultType="com.ottproject.ottbackend.dto.StatusOptionDto">
+        SELECT DISTINCT 
+            status AS key,
+            CASE 
+                WHEN status = 'ONGOING' THEN '방영중'
+                WHEN status = 'COMPLETED' THEN '완결'
+                WHEN status = 'UPCOMING' THEN '방영예정'
+                WHEN status = 'HIATUS' THEN '방영중단'
+                ELSE status
+            END AS label
+        FROM anime
+        WHERE is_active = TRUE AND status IS NOT NULL
+        ORDER BY status ASC
+    </select>
+
+    <!-- 마스터: 전체 타입 목록 -->
+    <select id="findAllTypes" resultType="com.ottproject.ottbackend.dto.TypeOptionDto">
+        SELECT DISTINCT 
+            type AS key,
+            type AS label
+        FROM anime
+        WHERE is_active = TRUE AND type IS NOT NULL
+        ORDER BY type ASC
     </select>
 
     <!--

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -6,6 +6,12 @@ const nextConfig: NextConfig = {
     forceSwcTransforms: true,
     esmExternals: 'loose',
   },
+  // 개발 모드에서 콘솔 로그 활성화
+  logging: {
+    fetches: {
+      fullUrl: true,
+    },
+  },
   compiler: {
     styledComponents: true,
   },

--- a/frontend/src/components/search/AnimeGrid.module.css
+++ b/frontend/src/components/search/AnimeGrid.module.css
@@ -142,21 +142,9 @@
   border-radius: 9999px;
   font-size: 0.875rem;
   font-weight: 500;
-}
-
-.searchCriteriaTagSearch {
-  background-color: #f3e8ff;
-  color: #7c3aed;
-}
-
-.searchCriteriaTagGenre {
-  background-color: #dbeafe;
-  color: #2563eb;
-}
-
-.searchCriteriaTagTag {
-  background-color: #dcfce7;
-  color: #16a34a;
+  background-color: #000000;
+  color: #ffffff;
+  border: 1px solid #666666;
 }
 
 /* 애니메 그리드 */

--- a/frontend/src/components/search/AnimeGrid.tsx
+++ b/frontend/src/components/search/AnimeGrid.tsx
@@ -9,6 +9,9 @@ interface AnimeGridProps {
   searchQuery: string;
   selectedGenres: string[];
   selectedTags: string[];
+  selectedSeasons: string[];
+  selectedStatuses: string[];
+  selectedTypes: string[];
   sortBy: string;
   onSortChange: (sort: string) => void;
   onAnimeClick: (anime: any) => void;
@@ -25,12 +28,15 @@ export default function AnimeGrid({
   searchQuery,
   selectedGenres,
   selectedTags,
+  selectedSeasons,
+  selectedStatuses,
+  selectedTypes,
   sortBy,
   onSortChange,
   onAnimeClick
 }: AnimeGridProps) {
   // 검색 조건이 있는지 확인
-  const hasSearchCriteria = searchQuery.trim() || selectedGenres.length > 0 || selectedTags.length > 0 || animes.length > 0;
+  const hasSearchCriteria = searchQuery.trim() || selectedGenres.length > 0 || selectedTags.length > 0 || selectedSeasons.length > 0 || selectedStatuses.length > 0 || selectedTypes.length > 0 || animes.length > 0;
 
   if (isLoading) {
     return (
@@ -111,21 +117,36 @@ export default function AnimeGrid({
         </div>
         
         {/* 검색 조건 표시 */}
-        {(searchQuery.trim() || selectedGenres.length > 0 || selectedTags.length > 0) && (
+        {(searchQuery.trim() || selectedGenres.length > 0 || selectedTags.length > 0 || selectedSeasons.length > 0 || selectedStatuses.length > 0 || selectedTypes.length > 0) && (
           <div className={styles.searchCriteria}>
             {searchQuery.trim() && (
-              <span className={`${styles.searchCriteriaTag} ${styles.searchCriteriaTagSearch}`}>
-                검색어: {searchQuery}
+              <span className={styles.searchCriteriaTag}>
+                {searchQuery}
               </span>
             )}
             {selectedGenres.map((genre) => (
-              <span key={genre} className={`${styles.searchCriteriaTag} ${styles.searchCriteriaTagGenre}`}>
-                장르: {genre}
+              <span key={genre} className={styles.searchCriteriaTag}>
+                {genre}
               </span>
             ))}
             {selectedTags.map((tag) => (
-              <span key={tag} className={`${styles.searchCriteriaTag} ${styles.searchCriteriaTagTag}`}>
-                태그: {tag}
+              <span key={tag} className={styles.searchCriteriaTag}>
+                {tag}
+              </span>
+            ))}
+            {selectedSeasons.map((season) => (
+              <span key={season} className={styles.searchCriteriaTag}>
+                {season}
+              </span>
+            ))}
+            {selectedStatuses.map((status) => (
+              <span key={status} className={styles.searchCriteriaTag}>
+                {status === 'ONGOING' ? '방영중' : status === 'COMPLETED' ? '완결' : status === 'UPCOMING' ? '방영예정' : '방영중단'}
+              </span>
+            ))}
+            {selectedTypes.map((type) => (
+              <span key={type} className={styles.searchCriteriaTag}>
+                {type}
               </span>
             ))}
           </div>

--- a/frontend/src/components/search/FilterModal.module.css
+++ b/frontend/src/components/search/FilterModal.module.css
@@ -1,0 +1,225 @@
+/* 필터 모달 오버레이 */
+.modalOverlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.8);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+/* 모달 컨텐츠 */
+.modalContent {
+  background-color: #1a1a1a;
+  border-radius: 12px;
+  width: 90%;
+  max-width: 700px;
+  max-height: 80vh;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.5);
+}
+
+/* 모달 헤더 */
+.modalHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1.5rem;
+  border-bottom: 1px solid #323232;
+}
+
+.headerContent {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  flex: 1;
+}
+
+.modalTitle {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #F7F7F7;
+  margin: 0 0 0.5rem 0;
+}
+
+.closeButton {
+  background: none;
+  border: none;
+  color: #ABABAB;
+  font-size: 1.5rem;
+  cursor: pointer;
+  padding: 0.25rem;
+  line-height: 1;
+  transition: color 0.2s;
+}
+
+.closeButton:hover {
+  color: #F7F7F7;
+}
+
+/* 모달 설명 */
+.modalDescription {
+  color: #ABABAB;
+  font-size: 0.875rem;
+  line-height: 1.4;
+  margin: 0;
+}
+
+/* 모달 바디 */
+.modalBody {
+  padding: 0 0.25rem 1.5rem 0.25rem;
+  overflow-y: auto;
+  flex: 1;
+}
+
+.checkboxGrid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 0.5rem;
+}
+
+.checkboxItem {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  cursor: pointer;
+  padding: 0.25rem;
+  border-radius: 0.25rem;
+}
+
+.checkboxItem:hover {
+  background-color: #2a2a2a;
+}
+
+.checkboxItem:hover .checkbox {
+  border-color: #7c3aed;
+}
+
+.checkbox {
+  width: 1rem;
+  height: 1rem;
+  color: #7c3aed;
+  background-color: #1a1a1a;
+  border: 2px solid #404040;
+  border-radius: 0.25rem;
+  cursor: pointer;
+  appearance: none;
+  position: relative;
+}
+
+.checkbox:focus {
+  outline: 2px solid #7c3aed;
+  outline-offset: 2px;
+}
+
+.checkbox:hover {
+  outline: none;
+  border-color: #7c3aed;
+}
+
+.checkbox:checked {
+  background-color: #1a1a1a;
+  border-color: #7c3aed;
+  outline: none;
+}
+
+.checkbox:checked::after {
+  content: '✓';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  color: #7c3aed;
+  font-size: 0.75rem;
+  font-weight: bold;
+}
+
+.checkbox:checked:hover {
+  outline: none;
+  border-color: #7c3aed;
+}
+
+.checkboxLabel {
+  color: #ABABAB;
+  font-size: 0.875rem;
+}
+
+/* 체크박스 타입별 색상 */
+.genreCheckbox,
+.tagCheckbox,
+.seasonCheckbox,
+.statusCheckbox,
+.typeCheckbox {
+  color: #7c3aed;
+}
+
+.genreCheckbox:focus,
+.tagCheckbox:focus,
+.seasonCheckbox:focus,
+.statusCheckbox:focus,
+.typeCheckbox:focus {
+  outline-color: #7c3aed;
+}
+
+.genreCheckbox:checked,
+.tagCheckbox:checked,
+.seasonCheckbox:checked,
+.statusCheckbox:checked,
+.typeCheckbox:checked {
+  background-color: #1a1a1a;
+  border-color: #7c3aed;
+}
+
+/* 모달 푸터 */
+.modalFooter {
+  padding: 1.5rem;
+  border-top: 1px solid #323232;
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 1rem;
+}
+
+.resetButton {
+  background: none;
+  color: #ABABAB;
+  border: none;
+  padding: 0.5rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: color 0.2s;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.resetButton:hover {
+  color: #F7F7F7;
+}
+
+.resetIcon {
+  font-size: 1rem;
+  color: #ABABAB;
+}
+
+.confirmButton {
+  background: none;
+  color: #7c3aed;
+  border: none;
+  padding: 0.5rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: color 0.2s;
+}
+
+.confirmButton:hover {
+  color: #6d28d9;
+}

--- a/frontend/src/components/search/FilterModal.tsx
+++ b/frontend/src/components/search/FilterModal.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { useState } from "react";
+import styles from "./FilterModal.module.css";
+
+interface FilterModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  title: string;
+  items: { id?: number; key?: string; name: string; label?: string }[];
+  selectedItems: (number | string)[];
+  onItemToggle: (item: number | string) => void;
+  onResetAll: () => void;
+  type: 'genre' | 'tag' | 'season' | 'status' | 'type';
+}
+
+/**
+ * 필터 모달 컴포넌트
+ * 더보기 버튼 클릭 시 나타나는 모달로 모든 필터 옵션을 표시
+ */
+export default function FilterModal({
+  isOpen,
+  onClose,
+  title,
+  items,
+  selectedItems,
+  onItemToggle,
+  onResetAll,
+  type
+}: FilterModalProps) {
+  if (!isOpen) return null;
+
+  const handleItemClick = (item: number | string) => {
+    onItemToggle(item);
+  };
+
+  const getItemKey = (item: any) => {
+    return item.id || item.key || item.name;
+  };
+
+  const getItemLabel = (item: any) => {
+    return item.label || item.name;
+  };
+
+  return (
+    <div className={styles.modalOverlay} onClick={onClose}>
+      <div className={styles.modalContent} onClick={(e) => e.stopPropagation()}>
+        <div className={styles.modalHeader}>
+          <div className={styles.headerContent}>
+            <h2 className={styles.modalTitle}>{title}</h2>
+            <div className={styles.modalDescription}>
+              원치 않는 필터는 체크 박스를 한번 더 누르면 제외 할 수 있어요.
+            </div>
+          </div>
+          <button className={styles.closeButton} onClick={onClose}>
+            ×
+          </button>
+        </div>
+        
+        <div className={styles.modalBody}>
+          <div className={styles.checkboxGrid}>
+            {items.map((item) => {
+              const key = getItemKey(item);
+              const label = getItemLabel(item);
+              const isSelected = selectedItems.includes(key);
+              
+              return (
+                <label key={key} className={styles.checkboxItem}>
+                  <input
+                    type="checkbox"
+                    checked={isSelected}
+                    onChange={() => handleItemClick(key)}
+                    className={`${styles.checkbox} ${styles[`${type}Checkbox`]}`}
+                  />
+                  <span className={styles.checkboxLabel}>{label}</span>
+                </label>
+              );
+            })}
+          </div>
+        </div>
+        
+        <div className={styles.modalFooter}>
+          <button className={styles.resetButton} onClick={onResetAll}>
+            <svg className={styles.resetIcon} width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M3 12a9 9 0 0 1 9-9 9.75 9.75 0 0 1 6.74 2.74L21 8"/>
+              <path d="M21 3v5h-5"/>
+              <path d="M21 12a9 9 0 0 1-9 9 9.75 9.75 0 0 1-6.74-2.74L3 16"/>
+              <path d="M3 21v-5h5"/>
+            </svg>
+            전체 초기화
+          </button>
+          <button className={styles.confirmButton} onClick={onClose}>
+            확인
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/search/FilterSidebar.module.css
+++ b/frontend/src/components/search/FilterSidebar.module.css
@@ -112,10 +112,12 @@
   width: 1rem;
   height: 1rem;
   color: #7c3aed;
-  background-color: #323232;
-  border: 1px solid #404040;
+  background-color: #1a1a1a;
+  border: 2px solid #404040;
   border-radius: 0.25rem;
   cursor: pointer;
+  appearance: none;
+  position: relative;
 }
 
 .checkbox:focus {
@@ -123,27 +125,62 @@
   outline-offset: 2px;
 }
 
+.checkbox:hover {
+  outline: none;
+  border-color: #7c3aed;
+}
+
+.checkbox:checked {
+  background-color: #1a1a1a;
+  border-color: #7c3aed;
+  outline: none;
+}
+
+.checkbox:checked:hover {
+  outline: none;
+  border-color: #7c3aed;
+}
+
+.checkbox:checked::after {
+  content: '✓';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  color: #7c3aed;
+  font-size: 0.75rem;
+  font-weight: bold;
+}
+
 .checkboxLabel {
   color: #ABABAB;
   font-size: 0.875rem;
 }
 
-/* 장르 체크박스 특별 스타일 */
-.genreCheckbox {
+/* 모든 체크박스 통일된 스타일 */
+.genreCheckbox,
+.tagCheckbox,
+.yearCheckbox,
+.statusCheckbox,
+.typeCheckbox {
   color: #7c3aed;
 }
 
-.genreCheckbox:focus {
+.genreCheckbox:focus,
+.tagCheckbox:focus,
+.yearCheckbox:focus,
+.statusCheckbox:focus,
+.typeCheckbox:focus {
   outline-color: #7c3aed;
 }
 
-/* 태그 체크박스 특별 스타일 */
-.tagCheckbox {
-  color: #2563eb;
-}
-
-.tagCheckbox:focus {
-  outline-color: #2563eb;
+.genreCheckbox:checked,
+.tagCheckbox:checked,
+.yearCheckbox:checked,
+.statusCheckbox:checked,
+.typeCheckbox:checked {
+  background-color: #1a1a1a;
+  border-color: #7c3aed;
 }
 
 /* 셀렉트 박스 */

--- a/frontend/src/components/search/FilterSidebar.tsx
+++ b/frontend/src/components/search/FilterSidebar.tsx
@@ -1,10 +1,15 @@
 "use client";
 
+import { useState } from "react";
 import styles from "./FilterSidebar.module.css";
+import FilterModal from "./FilterModal";
 
 interface FilterSidebarProps {
   selectedGenreIds: number[];
   selectedTagIds: number[];
+  selectedSeasons: string[];
+  selectedStatuses: string[];
+  selectedTypes: string[];
   filters: {
     watchable: boolean;
     membership: boolean;
@@ -15,12 +20,15 @@ interface FilterSidebarProps {
   selectedType?: string | null;
   genreOptions: { id: number; name: string; color?: string }[];
   tagOptions: { id: number; name: string; color?: string }[];
+  seasonOptions: string[];
+  statusOptions: {key: string; label: string}[];
+  typeOptions: {key: string; label: string}[];
   onGenreChange: (genreId: number) => void;
   onTagChange: (tagId: number) => void;
+  onSeasonChange: (season: string) => void;
+  onStatusChange: (status: string) => void;
+  onTypeChange: (type: string) => void;
   onFilterChange: (key: string, value: boolean) => void;
-  onYearChange?: (year: number | null) => void;
-  onStatusChange?: (status: string | null) => void;
-  onTypeChange?: (type: string | null) => void;
   onResetFilters: () => void;
 }
 
@@ -31,6 +39,9 @@ interface FilterSidebarProps {
 export default function FilterSidebar({
   selectedGenreIds,
   selectedTagIds,
+  selectedSeasons,
+  selectedStatuses,
+  selectedTypes,
   filters,
   searchQuery,
   selectedYear,
@@ -38,24 +49,30 @@ export default function FilterSidebar({
   selectedType,
   genreOptions,
   tagOptions,
+  seasonOptions,
+  statusOptions,
+  typeOptions,
   onGenreChange,
   onTagChange,
-  onFilterChange,
-  onYearChange,
+  onSeasonChange,
   onStatusChange,
   onTypeChange,
+  onFilterChange,
   onResetFilters
 }: FilterSidebarProps) {
+  // 백엔드에서 이미 번역된 데이터 사용
   const genres = genreOptions ?? [];
   const tags = tagOptions ?? [];
+  const seasons = seasonOptions ?? [];
+  const statuses = statusOptions ?? [];
+  const types = typeOptions ?? [];
 
-  const years = Array.from({length: 6}, (_, i) => new Date().getFullYear() - i);
-  const statuses = [
-    { key: 'ONGOING', label: '방영중' },
-    { key: 'COMPLETED', label: '완결' },
-    { key: 'UPCOMING', label: '방영예정' },
-    { key: 'HIATUS', label: '방영중단' },
-  ];
+  // 더보기 상태 관리
+  const [showMoreGenres, setShowMoreGenres] = useState(false);
+  const [showMoreTags, setShowMoreTags] = useState(false);
+  const [showMoreSeasons, setShowMoreSeasons] = useState(false);
+  const [showMoreStatuses, setShowMoreStatuses] = useState(false);
+  const [showMoreTypes, setShowMoreTypes] = useState(false);
 
   return (
     <div className={styles.filterSidebar}>
@@ -79,16 +96,17 @@ export default function FilterSidebar({
       <div className={styles.filterSection}>
         <div className={styles.filterSectionHeader}>
           <h3 className={styles.filterSectionTitle}>
-            장르 {selectedGenreIds.length > 0 && (
-              <span className={styles.filterCount}>({selectedGenreIds.length}개 선택)</span>
-            )}
+            장르
           </h3>
-          <button className={styles.moreButton}>
+          <button 
+            className={styles.moreButton}
+            onClick={() => setShowMoreGenres(true)}
+          >
             더 보기 &gt;
           </button>
         </div>
         <div className={styles.checkboxList}>
-          {genres.map((genre) => (
+          {genres.slice(0, 5).map((genre) => (
             <label key={genre.id} className={styles.checkboxItem}>
               <input
                 type="checkbox"
@@ -106,16 +124,17 @@ export default function FilterSidebar({
       <div className={styles.filterSection}>
         <div className={styles.filterSectionHeader}>
           <h3 className={styles.filterSectionTitle}>
-            태그 {selectedTagIds.length > 0 && (
-              <span className={styles.filterCount}>({selectedTagIds.length}개 선택)</span>
-            )}
+            태그
           </h3>
-          <button className={styles.moreButton}>
+          <button 
+            className={styles.moreButton}
+            onClick={() => setShowMoreTags(true)}
+          >
             더 보기 &gt;
           </button>
         </div>
         <div className={styles.checkboxList}>
-          {tags.map((tag) => (
+          {tags.slice(0, 5).map((tag) => (
             <label key={tag.id} className={styles.checkboxItem}>
               <input
                 type="checkbox"
@@ -129,52 +148,159 @@ export default function FilterSidebar({
         </div>
       </div>
 
-      {/* 연도 필터 */}
-      <div className={styles.selectContainer}>
-        <div className={styles.selectLabel}>연도</div>
-        <select
-          value={selectedYear ?? ''}
-          onChange={(e) => onYearChange?.(e.target.value ? Number(e.target.value) : null)}
-          className={styles.select}
-        >
-          <option value="">전체</option>
-          {years.map(y => (
-            <option key={y} value={y}>{y}</option>
+      {/* 시즌 필터 */}
+      <div className={styles.filterSection}>
+        <div className={styles.filterSectionHeader}>
+          <h3 className={styles.filterSectionTitle}>
+            년도
+          </h3>
+          <button 
+            className={styles.moreButton}
+            onClick={() => setShowMoreSeasons(true)}
+          >
+            더 보기 &gt;
+          </button>
+        </div>
+        <div className={styles.checkboxList}>
+          {seasons.slice(0, 5).map((season) => (
+            <label key={season} className={styles.checkboxItem}>
+              <input
+                type="checkbox"
+                checked={selectedSeasons.includes(season)}
+                onChange={() => onSeasonChange(season)}
+                className={`${styles.checkbox} ${styles.yearCheckbox}`}
+              />
+              <span className={styles.checkboxLabel}>{season}</span>
+            </label>
           ))}
-        </select>
+        </div>
       </div>
 
       {/* 방영 상태 필터 */}
-      <div className={styles.selectContainer}>
-        <div className={styles.selectLabel}>방영 상태</div>
-        <select
-          value={selectedStatus ?? ''}
-          onChange={(e) => onStatusChange?.(e.target.value ? e.target.value : null)}
-          className={styles.select}
-        >
-          <option value="">전체</option>
-          {statuses.map(s => (
-            <option key={s.key} value={s.key}>{s.label}</option>
+      <div className={styles.filterSection}>
+        <div className={styles.filterSectionHeader}>
+          <h3 className={styles.filterSectionTitle}>
+            방영
+          </h3>
+          <button 
+            className={styles.moreButton}
+            onClick={() => setShowMoreStatuses(true)}
+          >
+            더 보기 &gt;
+          </button>
+        </div>
+        <div className={styles.checkboxList}>
+          {statuses.slice(0, 5).map((status) => (
+            <label key={status.key} className={styles.checkboxItem}>
+              <input
+                type="checkbox"
+                checked={selectedStatuses.includes(status.key)}
+                onChange={() => onStatusChange(status.key)}
+                className={`${styles.checkbox} ${styles.statusCheckbox}`}
+              />
+              <span className={styles.checkboxLabel}>{status.label}</span>
+            </label>
           ))}
-        </select>
+        </div>
       </div>
 
       {/* 출시 타입 필터 */}
-      <div className={styles.selectContainer}>
-        <div className={styles.selectLabel}>출시 타입</div>
-        <select
-          value={selectedType ?? ''}
-          onChange={(e) => onTypeChange?.(e.target.value ? e.target.value : null)}
-          className={styles.select}
-        >
-          <option value="">전체</option>
-          <option value="TV">TV</option>
-          <option value="MOVIE">MOVIE</option>
-          <option value="OVA">OVA</option>
-          <option value="SPECIAL">SPECIAL</option>
-          <option value="WEB">WEB</option>
-        </select>
+      <div className={styles.filterSection}>
+        <div className={styles.filterSectionHeader}>
+          <h3 className={styles.filterSectionTitle}>
+            출시타입
+          </h3>
+          <button 
+            className={styles.moreButton}
+            onClick={() => setShowMoreTypes(true)}
+          >
+            더 보기 &gt;
+          </button>
+        </div>
+        <div className={styles.checkboxList}>
+          {types.slice(0, 5).map((type) => (
+            <label key={type.key} className={styles.checkboxItem}>
+              <input
+                type="checkbox"
+                checked={selectedTypes.includes(type.key)}
+                onChange={() => onTypeChange(type.key)}
+                className={`${styles.checkbox} ${styles.typeCheckbox}`}
+              />
+              <span className={styles.checkboxLabel}>{type.label}</span>
+            </label>
+          ))}
+        </div>
       </div>
+
+      {/* 장르 모달 */}
+      <FilterModal
+        isOpen={showMoreGenres}
+        onClose={() => setShowMoreGenres(false)}
+        title="장르 전체"
+        items={genres}
+        selectedItems={selectedGenreIds}
+        onItemToggle={onGenreChange}
+        onResetAll={() => {
+          selectedGenreIds.forEach(id => onGenreChange(id));
+        }}
+        type="genre"
+      />
+
+      {/* 태그 모달 */}
+      <FilterModal
+        isOpen={showMoreTags}
+        onClose={() => setShowMoreTags(false)}
+        title="태그 전체"
+        items={tags}
+        selectedItems={selectedTagIds}
+        onItemToggle={onTagChange}
+        onResetAll={() => {
+          selectedTagIds.forEach(id => onTagChange(id));
+        }}
+        type="tag"
+      />
+
+      {/* 시즌 모달 */}
+      <FilterModal
+        isOpen={showMoreSeasons}
+        onClose={() => setShowMoreSeasons(false)}
+        title="년도 전체"
+        items={seasons.map(season => ({ key: season, name: season }))}
+        selectedItems={selectedSeasons}
+        onItemToggle={onSeasonChange}
+        onResetAll={() => {
+          selectedSeasons.forEach(season => onSeasonChange(season));
+        }}
+        type="season"
+      />
+
+      {/* 상태 모달 */}
+      <FilterModal
+        isOpen={showMoreStatuses}
+        onClose={() => setShowMoreStatuses(false)}
+        title="방영 전체"
+        items={statuses}
+        selectedItems={selectedStatuses}
+        onItemToggle={onStatusChange}
+        onResetAll={() => {
+          selectedStatuses.forEach(status => onStatusChange(status));
+        }}
+        type="status"
+      />
+
+      {/* 타입 모달 */}
+      <FilterModal
+        isOpen={showMoreTypes}
+        onClose={() => setShowMoreTypes(false)}
+        title="출시타입 전체"
+        items={types}
+        selectedItems={selectedTypes}
+        onItemToggle={onTypeChange}
+        onResetAll={() => {
+          selectedTypes.forEach(type => onTypeChange(type));
+        }}
+        type="type"
+      />
     </div>
   );
 }

--- a/frontend/src/lib/api/anime.ts
+++ b/frontend/src/lib/api/anime.ts
@@ -142,3 +142,16 @@ export async function getGenres() {
 export async function getTags() {
   return apiCall('/anime/tags');
 }
+
+// 필터 옵션 목록
+export async function getSeasons() {
+  return apiCall('/anime/seasons');
+}
+
+export async function getStatuses() {
+  return apiCall('/anime/statuses');
+}
+
+export async function getTypes() {
+  return apiCall('/anime/types');
+}


### PR DESCRIPTION
feat: add filter option endpoints and tag filtering support

- Add status and type filter option endpoints (/api/anime/statuses, /api/anime/types)
- Implement tag OR filtering in anime list queries
- Add cursor-based pagination support for infinite scroll
- Add debug logging for anime detail queries

feat: add filter option DTOs

- Add StatusOptionDto for anime status filter options
- Add TypeOptionDto for anime type filter options

feat: implement infinite scroll and enhanced filtering

- Add infinite scroll with cursor-based pagination in tags page
- Implement comprehensive filter sidebar with genre, tag, status, type filters
- Add filter modal for expanded filter options
- Enhance anime grid with improved styling and data handling
- Update API client with new filter endpoints and cursor support

feat: add filter modal component

- Add FilterModal component for expanded filter selection
- Implement responsive modal design with checkbox grid layout
- Support multiple filter types (genre, tag, season, status, type)